### PR TITLE
fix(cloudflare-ddns): redirect log output to stderr

### DIFF
--- a/kubernetes/apps/networking/cloudflare-ddns/app/scripts/cloudflare-ddns.sh
+++ b/kubernetes/apps/networking/cloudflare-ddns/app/scripts/cloudflare-ddns.sh
@@ -5,9 +5,9 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-# Function to log messages
+# Function to log messages (to stderr so log lines don't contaminate command substitution output)
 log() {
-    echo "$(date -u) - $1"
+    echo "$(date -u) - $1" >&2
 }
 
 # Function to exit in case of an error


### PR DESCRIPTION
## Summary
- Fix regression introduced by #1605: the retry helper's `log` calls were written to stdout, so $(retry curl ...) captured log lines mixed with the actual response, breaking jq parsing and causing all DDNS cronjob runs to fail with exit 1.
- Change `log()` to write to stderr instead.

## Evidence from cluster
Before this fix, `cloudflare-ddns-29632140-*` pods in `networking` ns were erroring with:
```
Mon May  4 21:01:15 UTC 2026 - Fetched current IP Address: Mon May  4 21:01:15 UTC 2026 - Attempt 1/3: curl
24.18.52.209
jq: parse error: Invalid numeric literal at line 1, column 4
Mon May  4 21:01:15 UTC 2026 - Error: Failed to fetch Cloudflare Zone ID after multiple attempts
```
With this change, log lines go to stderr and $() captures only the curl response body, so jq parsing succeeds.
