### PR TITLE
fix(utilities): disable k8sgpt kustomization (CRD missing after upgrade)

### DIFF
--- a/kubernetes/apps/utilities/kustomization.yaml
+++ b/kubernetes/apps/utilities/kustomization.yaml
@@ -18,4 +18,4 @@ resources:
   - ./brother-ql-web/ks.yaml
   - ./forgejo/ks.yaml
   - ./it-tools/ks.yaml
-  - ./k8sgpt/ks.yaml
+    #- ./k8sgpt/ks.yaml


### PR DESCRIPTION
## Summary
- Disable the k8sgpt kustomization after the 0.2.27 chart upgrade (#1460 / #1452).
- The chart does not ship the `k8sgpts.core.k8sgpt.ai` CRD; it must be installed separately (per [upstream docs](https://docs.k8sgpt.ai/reference/operator/advanced-installation/)).
- Our config/k8sgpt.yaml tries to apply a `K8sGPT` CR, which fails without the CRD, breaking `cluster-utilities-k8sgpt-config` kustomization.

## Symptom
```
K8sGPT/utilities/k8sgpt not found: the server could not find the requested resource (patch k8sgpts.core.k8sgpt.ai k8sgpt)
```

## Follow-up
Either add the CRD resource to the app kustomization (there's a commented-out `app/crds/k8sgpt.yaml` that can be re-enabled once validated), or switch the helm chart to one that installs CRDs.
