### PR TITLE
feat(databases/mariadb): enable autoUpdateDataPlane for operator v26 upgrade

### DIFF
--- a/kubernetes/apps/databases/mariadb-operator/instances/mariadb.yaml
+++ b/kubernetes/apps/databases/mariadb-operator/instances/mariadb.yaml
@@ -43,6 +43,7 @@ spec:
 
   updateStrategy:
     type: RollingUpdate
+    autoUpdateDataPlane: true  # required before operator upgrade to 26.3.x per upstream UPGRADE_26.3.0.md
 
   nodeSelector:
     node-role.kubernetes.io/worker: 'true'


### PR DESCRIPTION
## Summary
Prerequisite for #1384 (mariadb-operator-crds 26.3.0) and #1383 (mariadb-operator 26.3.0).

Upstream [UPGRADE_26.3.0.md](https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_26.3.0.md) requires:
> You must set `updateStrategy.autoUpdateDataPlane=true` in your `MariaDB` resources **before** updating the operator.

Without this, the new operator runs but refuses to roll the data-plane, leaving the operator/data-plane at mismatched versions.

## After this merges
1. Confirm `kubectl get mariadb -n databases mariadb-operator -o yaml | grep autoUpdateDataPlane` → `true`
2. Take a MariaDB backup
3. Merge #1384 (CRDs)
4. Merge #1383 (operator)
5. Watch data-plane roll; verify `READY=True`
6. Optionally revert `autoUpdateDataPlane` back to false in a follow-up
