### PR TITLE
fix(vllm-classifier): remove --disable-log-requests (removed in vllm v0.20)

### DIFF
--- a/kubernetes/apps/home/vllm-classifier/app/helm-release.yaml
+++ b/kubernetes/apps/home/vllm-classifier/app/helm-release.yaml
@@ -56,8 +56,9 @@ spec:
                        --quantization awq \
                        --host 0.0.0.0 \
                        --port 8000 \
-                       --dtype auto \
-                       --disable-log-requests
+                       --dtype auto
+                   # NOTE: --disable-log-requests was removed in vllm v0.20
+                   # (replaced by opt-in --enable-log-requests; default is no request logging).
             env:
               - name: TZ
                 value: ${TIMEZONE}


### PR DESCRIPTION
## Summary
Fix CrashLoopBackOff introduced by #1352 (vllm v0.19 \u2192 v0.20).

```
vllm: error: unrecognized arguments: --disable-log-requests
ERROR: init 250 result=11
```

vllm v0.20 removed `--disable-log-requests`; request logging is now off by default and opt-in via `--enable-log-requests`. Removing the flag restores equivalent behavior.

Affects: `home/vllm-classifier` only (main `vllm` HR does not use this flag).