### PR TITLE
fix(webfinger): restructure probes to match bjw-s app-template 4.3 schema

### DIFF
--- a/kubernetes/apps/networking/webfinger/app/helm-release.yaml
+++ b/kubernetes/apps/networking/webfinger/app/helm-release.yaml
@@ -33,31 +33,37 @@ spec:
             probes:
               liveness:
                 enabled: true
-                type: HTTP
-                path: /
-                port: 80
-                initialDelaySeconds: 30
-                periodSeconds: 10
-                timeoutSeconds: 5
-                failureThreshold: 3
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 80
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
               readiness:
                 enabled: true
-                type: HTTP
-                path: /
-                port: 80
-                initialDelaySeconds: 5
-                periodSeconds: 5
-                timeoutSeconds: 3
-                failureThreshold: 3
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 80
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 3
+                  failureThreshold: 3
               startup:
                 enabled: true
-                type: HTTP
-                path: /
-                port: 80
-                initialDelaySeconds: 5
-                periodSeconds: 5
-                timeoutSeconds: 3
-                failureThreshold: 30
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 80
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 3
+                  failureThreshold: 30
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
## Summary
Fix schema validation failure on webfinger HelmRelease introduced by #1544.

The probes block used the flat schema (`type: HTTP`, `path: /`, `port: 80` + `initialDelaySeconds` etc. as direct fields), but bjw-s app-template 4.3 requires `custom: true` + nested `spec.httpGet` structure.

Actual flux error:
```
at '/controllers/main/containers/main/probes/readiness':
  additional properties 'failureThreshold', 'initialDelaySeconds', 'periodSeconds', 'timeoutSeconds' not allowed
```

Same pattern already used elsewhere (subgen-worker, vllm-classifier).