### PR TITLE
chore(multus): prepare cluster for multus deployment

### DIFF
--- a/kubernetes/apps/home/esphome/ks.yaml
+++ b/kubernetes/apps/home/esphome/ks.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   dependsOn:
     - name: cluster-storage-longhorn
-    #- name: cluster-networking-multus
+    #- name: cluster-multus-networks
   path: ./kubernetes/apps/home/esphome/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/home-assistant/ks.yaml
+++ b/kubernetes/apps/home/home-assistant/ks.yaml
@@ -11,7 +11,7 @@ spec:
   dependsOn:
     - name: cluster-storage-longhorn
     - name: cluster-databases-postgres-clusters
-    #- name: cluster-networking-multus
+    #- name: cluster-multus-networks
   path: ./kubernetes/apps/home/home-assistant/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/monica/ks.yaml
+++ b/kubernetes/apps/home/monica/ks.yaml
@@ -11,7 +11,6 @@ spec:
   dependsOn:
     - name: cluster-storage-longhorn
     - name: cluster-databases-postgres-clusters
-    #- name: cluster-networking-multus
   path: ./kubernetes/apps/home/monica/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/zwavejs/ks.yaml
+++ b/kubernetes/apps/home/zwavejs/ks.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   dependsOn:
     - name: cluster-storage-longhorn
+    #- name: cluster-multus-networks
   path: ./kubernetes/apps/home/zwavejs/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
@@ -19,7 +19,10 @@ cluster:
   id: 1
   name: "home-kubernetes"
 cni:
-  exclusive: true
+  # exclusive must be false to allow Multus to write /etc/cni/net.d/00-multus.conf.
+  # Cilium remains the delegate/default network via multus's config; see
+  # kubernetes/apps/kube-system/multus/app/resources/00-multus.conf
+  exclusive: false
 # NOTE: devices might need to be set if you have more than one active NIC on your hosts
 devices: eno+ eth+ enp+
 enableIPv4BIGTCP: true

--- a/kubernetes/apps/kube-system/multus/networks/networkattachdefinition.yaml
+++ b/kubernetes/apps/kube-system/multus/networks/networkattachdefinition.yaml
@@ -1,4 +1,14 @@
 ---
+# The Talos machine config bonds every physical interface (eno1 + enp0s20f0u3)
+# into eth0 (see kubernetes/bootstrap/talos/talconfig.yaml). macvlan cannot be
+# created on a bond slave, so the macvlan master must be the bond itself.
+#
+# TODO(ipam): host-local IPAM is per-node state, so if two nodes each assign
+# 192.168.6.5 there will be an L2 IP conflict. Current consumers (esphome,
+# zwavejs, home-assistant) are pinned to individual workers so collisions are
+# unlikely today. If additional multus consumers are added, migrate to
+# whereabouts IPAM (cluster-wide state via CRDs) or split this range into
+# per-node NADs.
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
@@ -8,7 +18,7 @@ spec:
       "cniVersion": "0.3.0",
       "type": "macvlan",
       "capabilities": { "dns": false },
-      "master": "enp0s20f0u3",
+      "master": "eth0",
       "mode": "bridge",
       "ipam": {
         "type": "host-local",

--- a/kubernetes/apps/kube-system/multus/networks/networkattachdefinition.yaml
+++ b/kubernetes/apps/kube-system/multus/networks/networkattachdefinition.yaml
@@ -3,7 +3,23 @@
 # into eth0 (see kubernetes/bootstrap/talos/talconfig.yaml). macvlan cannot be
 # created on a bond slave, so the macvlan master must be the bond itself.
 #
-# TODO(ipam): host-local IPAM is per-node state, so if two nodes each assign
+# ROUTE SCOPE — dst is deliberately 192.168.0.0/24 (the physical home-LAN
+# subnet where Sonos / Roomba / ESPHome / NAS / AdGuard live), NOT the whole
+# 192.168.0.0/20. If dst covered /20, the pod's routing table would send
+# traffic to 192.168.5.x (Cilium LoadBalancer VIPs like Mosquitto, Authelia,
+# LiteLLM) and 192.168.3.x (Talos node IPs) out the macvlan too. macvlan
+# cannot reach its own parent host, so any VIP announced by the same node
+# the pod runs on would silently fail — verified: worker-01 currently owns
+# home-mosquitto, home-litellm, networking-authelia leases, and home-assistant
+# is pinned to worker-01. See the CiliumL2Announcement leader elections in
+# `kubectl -n kube-system get lease | grep cilium-l2announce`.
+#
+# IPAM SUBNET — kept at /24 for the multus pool (192.168.6.0/24). The pod's
+# net1 gets an on-link route for 192.168.6.0/24 by kernel; the explicit
+# routes[] entry adds 192.168.0.0/24. Everything outside those two ranges
+# routes via the pod's default (eth0 / Cilium primary interface).
+#
+# TODO(ipam): host-local IPAM is per-node state. If two nodes each assign
 # 192.168.6.5 there will be an L2 IP conflict. Current consumers (esphome,
 # zwavejs, home-assistant) are pinned to individual workers so collisions are
 # unlikely today. If additional multus consumers are added, migrate to
@@ -22,11 +38,11 @@ spec:
       "mode": "bridge",
       "ipam": {
         "type": "host-local",
-        "subnet": "192.168.0.0/20",
+        "subnet": "192.168.6.0/24",
         "rangeStart": "192.168.6.1",
         "rangeEnd": "192.168.6.50",
         "routes": [
-          { "dst": "192.168.0.0/20" }
+          { "dst": "192.168.0.0/24" }
         ],
         "gateway": "192.168.0.1"
       }


### PR DESCRIPTION
## Summary

Multus is not deployed by this PR — it remains disabled in `kubernetes/apps/kube-system/kustomization.yaml` (`./multus/ks.yaml` stays commented). Every change here is a **prerequisite** so the switch can be flipped in a follow-up with a clean rollout.

Findings came from a full cluster audit against the existing (dormant) Multus manifests in `kubernetes/apps/kube-system/multus/`.

## Blockers fixed

### 1. Cilium was in exclusive-CNI mode
`kubernetes/apps/kube-system/cilium/app/helm-values.yaml` set `cni.exclusive: true`, which caused Cilium's agent to actively delete any CNI config in `/etc/cni/net.d/` that wasn't its own `05-cilium.conflist`. Multus's `00-multus.conf` would be repeatedly wiped.
- Set `cni.exclusive: false`
- Added a comment explaining why. Cilium still functions as the default network via Multus's delegate config (`multus/app/resources/00-multus.conf`).

**Rollout impact:** Cilium DaemonSet will roll after this merges. No datapath change beyond CNI-file management.

### 2. NAD macvlan master was a bond slave
Every worker's Talos config bonds all physical interfaces (`physical: true` deviceSelector) into `eth0`. Verified via `talosctl get link enp0s20f0u3 -o yaml`:
```
slaveKind: bond
masterIndex: 10   # -> bonded into eth0
flags: UP,BROADCAST,RUNNING,SLAVE,MULTICAST,LOWER_UP
```
macvlan cannot be attached to a bond slave — the kernel routes slave traffic through the bond master.
- Changed `master: enp0s20f0u3` → `master: eth0` in `networkattachdefinition.yaml`.
- macvlan-on-bond is a fully supported kernel path.

## Follow-up fix — NAD route scope (new commit `fix(multus): tighten NAD route`)

Stress-testing the initial `master: eth0` change against the live cluster surfaced a second problem: the previous route `dst: 192.168.0.0/20` covered the entire home network — INCLUDING `192.168.3.0/24` (Talos node IPs) and `192.168.5.0/24` (Cilium LoadBalancer VIPs).

macvlan cannot reach its own parent host. Any Cilium L2-announced VIP whose leader lease is currently held by the same node the multus-attached pod runs on would silently fail.

Verified against the live cluster: `home-assistant` is pinned to `worker-01`, and `worker-01` currently owns the L2 leases for:
- `networking-authelia` → `192.168.5.11`
- `home-mosquitto` → `192.168.5.6`
- `home-litellm` → `192.168.5.132`

Home Assistant uses Mosquitto continuously (MQTT integrations). Rolling out Multus with the `/20` route would have broken it hard the moment the pod was recreated with the multus annotation.

Tightened to `dst: 192.168.0.0/24` — the physical home-LAN subnet where Sonos / Roomba / ESPHome / NAS / AdGuard actually live. Everything else (VIPs, cluster IPs, internet) continues via Cilium eth0 as before.

`ipam.subnet` also tightened from `/20` to `/24` so the kernel's implicit on-link route for the pod's net1 matches the tightened pool. Explicit `routes[]` adds the `/24` static route through net1.

## Other cleanup

| File | Change |
|---|---|
| `apps/home/home-assistant/ks.yaml` | Fix commented dependsOn: `cluster-networking-multus` → `cluster-multus-networks` (matches the actual Kustomization name in `multus/ks.yaml:31`) |
| `apps/home/esphome/ks.yaml` | Same rename |
| `apps/home/zwavejs/ks.yaml` | Add (commented) `cluster-multus-networks` dependsOn — it uses the multus annotation but had no dependsOn |
| `apps/home/monica/ks.yaml` | Remove stale commented dependsOn — monica does not use `k8s.v1.cni.cncf.io/networks` |
| `multus/networks/networkattachdefinition.yaml` | Header comment documents the bond situation, the /24 route rationale, and the TODO on host-local IPAM collision risk |

## Verification against the live cluster

- Cluster: `admin@home-kubernetes` (Talos v1.12.x, k8s v1.36.x)
- No `NetworkAttachmentDefinition` CRD present (expected — Multus provides it)
- `/opt/cni/bin` on workers has `bridge, cilium-cni, firewall, flannel, host-local, loopback, portmap` — missing `macvlan`/`tuning`, which the Multus DS `install-cni` init container (`ghcr.io/siderolabs/install-cni:v1.9.0`) installs at first start.
- `/etc/cni/net.d/` contains only `05-cilium.conflist`. Multus will drop `00-multus.conf` which sorts first.
- Talos machine config (`patches/global/*.yaml`) has no hostile sysctls for macvlan; kernel 6.18.x-talos has `CONFIG_MACVLAN=m` built in.
- **MetalLB is NOT deployed.** Cilium performs LB IPAM via `CiliumLoadBalancerIPPool` (`l2-pool` at 192.168.5.128/25, `l2-pool-reserved` at 192.168.5.0/25) and L2 announcements via `CiliumL2AnnouncementPolicy`.

## Follow-up (NOT in this PR)

After merge, enable Multus by:
1. Uncommenting `- ./multus/ks.yaml` in `kubernetes/apps/kube-system/kustomization.yaml`.
2. Waiting for `cluster-multus` (DaemonSet) and `cluster-multus-networks` (NAD) to become ready.
3. Uncommenting `- name: cluster-multus-networks` in `home-assistant/esphome/zwavejs` ks.yaml files.
4. Recreating those pods; verifying `net1` interface + reachability to 192.168.0.0/24 devices.

## Other observations (not fixed here)

- `worker-03` has been NotReady since 2026-06-29 (kubelet stopped posting status). Unrelated to Multus but the DaemonSet health check will need to tolerate it.
- `worker-04` is defined in `talconfig.yaml:203-236` but is not in the cluster — pre-existing drift.
- ~22 stale `metallb.universe.tf/*` annotations across ~14 files. Filed as follow-up (`/fix` after this merges).