### PR TITLE
fix(ci): trust third-party Homebrew taps before brew bundle runs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -93,6 +93,22 @@ jobs:
         shell: bash
         run: brew install go-task
 
+      # Homebrew 6.0+ enforces HOMEBREW_REQUIRE_TAP_TRUST — third-party taps
+      # must be explicitly trusted before their formulae can be loaded, even
+      # from a Brewfile. `brew tap` alone is not sufficient (the tap is
+      # cloned but not trusted). See:
+      #   https://github.com/orgs/Homebrew/discussions/6898
+      #   https://github.com/homebrew/brew/issues/22551
+      # We trust every non-core tap referenced by the Brewfile so
+      # `brew bundle` can complete non-interactively. Idempotent.
+      - name: Trust third-party Homebrew taps
+        if: ${{ github.event_name == 'pull_request' && steps.cache-homebrew-packages.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          brew trust fluxcd/tap
+          brew trust go-task/tap
+          brew trust siderolabs/tap
+
       - name: Run Workstation Brew tasks
         if: ${{ github.event_name == 'pull_request' && steps.cache-homebrew-packages.outputs.cache-hit != 'true' }}
         shell: bash


### PR DESCRIPTION
## Summary

Fixes the `configure (talos)` e2e job that has been failing on every PR since Homebrew 6.0 shipped `HOMEBREW_REQUIRE_TAP_TRUST` as an enforced default. Third-party taps must now be explicitly trusted before their formulae can be loaded, even from a Brewfile.

## The failure

Every PR in the last several days shows (e.g. run [28669988257](https://github.com/lenaxia/talos-ops-prod/actions/runs/28669988257)):

```
##[error]Refusing to load formula fluxcd/tap/flux from untrusted tap fluxcd/tap.
Run `brew trust --formula fluxcd/tap/flux` or `brew trust fluxcd/tap` to trust it.
task: Failed to run task "workstation:brew": exit status 1
```

The `.taskfiles/workstation/Brewfile` uses three third-party taps: `fluxcd/tap`, `go-task/tap`, `siderolabs/tap`. Homebrew 6.0+ refuses to load formulae from any of them without explicit trust. `brew tap <name>` alone is not enough — the tap gets cloned but the trust bit is not set.

## The fix

Adds a step ahead of `Run Workstation Brew tasks` that runs `brew trust` on each of the three non-core taps referenced by the Brewfile. Gated on the same condition as the surrounding brew steps (`pull_request` event + cache miss), so it's a no-op when the Homebrew cache is warm.

```yaml
- name: Trust third-party Homebrew taps
  if: ${{ github.event_name == 'pull_request' && steps.cache-homebrew-packages.outputs.cache-hit != 'true' }}
  shell: bash
  run: |
    brew trust fluxcd/tap
    brew trust go-task/tap
    brew trust siderolabs/tap
```

`brew trust` is idempotent: it's safe to re-run and has no effect if the tap is already trusted.

## Not touched

- `workstation (generic-linux)` job is unaffected — it runs `brew install go-task` directly, and `setup-homebrew@main` appears to auto-trust that path. Currently passing, so not modified.

## References

- https://github.com/orgs/Homebrew/discussions/6898
- https://github.com/homebrew/brew/issues/22551

## Blast radius

**Low.** Workflow-only change. Cannot affect cluster state. Worst case: if `brew trust` misbehaves in CI, the step fails and the job is no worse off than it is today.