### PR TITLE
chore(talos): remove worker-03 from talconfig.yaml

### DIFF
--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -166,40 +166,6 @@ nodes:
         mtu: 1500
     patches:
       - "@./patches/global/containerd.yaml"
-  - hostname: "worker-03"
-    ipAddress: "192.168.3.23"
-    controlPlane: false
-    installDiskSelector:
-      model: CHN-mSATAQ3-120
-    nodeLabels: 
-      node-role.kubernetes.io/worker: true
-    networkInterfaces:
-      - interface: eth0
-        bond:
-          deviceSelectors:
-            - physical: true
-        dhcp: false
-        addresses:
-          - "192.168.3.23/16"
-        routes:
-          - network: 0.0.0.0/0
-            gateway: "192.168.0.1"
-        mtu: 1500
-    schematic:
-      customization:
-        systemExtensions:
-            officialExtensions:
-              - siderolabs/gasket-driver
-              - siderolabs/intel-ucode
-              - siderolabs/iscsi-tools
-              - siderolabs/util-linux-tools
-    userVolumes:
-      - name: longhorn
-        provisioning:
-          diskSelector: 
-            match: disk.transport == 'sata' && !system_disk
-          minSize: "500GiB" # Talos will autogrow the size if more is available
-          grow: true
   - hostname: "worker-04"
     ipAddress: "192.168.3.24"
     installDiskSelector:


### PR DESCRIPTION
## Summary

worker-03 has been NotReady since 2026-06-29 (kubelet stopped posting node status). Its Cilium DaemonSet pod was stuck in Terminating for 12+ hours, which caused Flux to fail the Cilium HelmRelease upgrade that PR #1924 landed (`cni.exclusive: false`), triggering an endless rollback loop and reverting the setting to `cni.exclusive: true`. This was blocking Multus enablement.

The node has been drained and removed from the cluster imperatively:

```
kubectl cordon worker-03
kubectl drain worker-03 --ignore-daemonsets --delete-emptydir-data --force --grace-period=0 --disable-eviction
kubectl delete node worker-03
kubectl delete pod -n kube-system cilium-f6fjb --force --grace-period=0
```

After deletion the Cilium DaemonSet reconciled cleanly to 6/6 and the HelmRelease is now `Ready=True` with `cni-exclusive: false` live in the ConfigMap. Cilium was also bumped from HR revision v30 to v76 during recovery (chart version unchanged at `1.19.5`).

This PR removes worker-03 from `talconfig.yaml` so it doesn't come back as a Talos configuration target. `worker-04` remains defined but not-joined (unchanged).

## Verification

```
$ kubectl get nodes
NAME        STATUS   ROLES           AGE    VERSION
cp-00       Ready    control-plane   334d   v1.35.3
cp-01       Ready    control-plane   133d   v1.35.3
cp-02       Ready    control-plane   96d    v1.35.3
worker-00   Ready    worker          334d   v1.35.3
worker-01   Ready    worker          132d   v1.35.3
worker-02   Ready    worker          334d   v1.35.3

$ kubectl -n kube-system get hr cilium
NAME     AGE    READY   STATUS
cilium   334d   True    Helm upgrade succeeded for release kube-system/cilium.v76 with chart cilium@1.19.5

$ kubectl -n kube-system get cm cilium-config -o jsonpath='{.data.cni-exclusive}'
false
```

## Blast radius

**Low.** Node has already been removed from the cluster; this PR just removes its Talos machine-config definition so it doesn't get re-provisioned. If the hardware is recovered later, re-add as worker-05 or with a new hostname (fresh Talos install + fresh Longhorn identity).

## Follow-up

- Multus enablement (previously gated on worker-03 recovery) is now unblocked. Separate PR.
- worker-04 remains defined in talconfig.yaml but not-joined — pre-existing drift, unchanged here.

Refs: PR #1924 (multus prep), PR #1928 (metallb cleanup).