### PR TITLE
fix(talos): convert JSON6902 patches to strategic-merge for multi-doc compat

### DIFF
--- a/kubernetes/bootstrap/talos/patches/controller/disable-admission-controller.yaml
+++ b/kubernetes/bootstrap/talos/patches/controller/disable-admission-controller.yaml
@@ -1,2 +1,4 @@
-- op: remove
-  path: /cluster/apiServer/admissionControl
+cluster:
+  apiServer:
+    admissionControl:
+      $$patch: delete

--- a/kubernetes/bootstrap/talos/patches/nvidia/nvidia-default-runtimeclass.yaml
+++ b/kubernetes/bootstrap/talos/patches/nvidia/nvidia-default-runtimeclass.yaml
@@ -1,10 +1,9 @@
-- op: add
-  path: /machine/files
-  value:
+machine:
+  files:
     - content: |
         [plugins]
           [plugins."io.containerd.cri.v1.runtime"]
             [plugins."io.containerd.cri.v1.runtime".containerd]
-              default_runtime_name = "nvidia"        
+              default_runtime_name = "nvidia"
       path: /etc/cri/conf.d/30-customization.part
       op: create

--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -32,6 +32,7 @@ nodes:
         bond:
           deviceSelectors:
             - physical: true
+          mode: balance-rr
         dhcp: false
         addresses:
           - "192.168.3.10/16"
@@ -50,6 +51,7 @@ nodes:
         bond:
           deviceSelectors:
             - physical: true
+          mode: balance-rr
         dhcp: false
         addresses:
           - "192.168.3.11/16"
@@ -68,6 +70,7 @@ nodes:
         bond:
           deviceSelectors:
             - physical: true
+          mode: balance-rr
         dhcp: false
         addresses:
           - "192.168.3.12/16"
@@ -103,6 +106,7 @@ nodes:
         bond:
           deviceSelectors:
             - physical: true
+          mode: balance-rr
         dhcp: false
         addresses:
           - "192.168.3.20/16"
@@ -136,6 +140,7 @@ nodes:
         bond:
           deviceSelectors:
             - physical: true
+          mode: balance-rr
         dhcp: false
         addresses:
           - "192.168.3.21/16"
@@ -157,6 +162,7 @@ nodes:
         bond:
           deviceSelectors:
             - physical: true
+          mode: balance-rr
         dhcp: false
         addresses:
           - "192.168.3.22/16"
@@ -178,6 +184,7 @@ nodes:
         bond:
           deviceSelectors:
             - physical: true
+          mode: balance-rr
         dhcp: false
         addresses:
           - "192.168.3.23/16"
@@ -212,6 +219,7 @@ nodes:
         bond:
           deviceSelectors:
             - physical: true
+          mode: balance-rr
         dhcp: false
         addresses:
           - "192.168.3.24/16"


### PR DESCRIPTION
## Summary

Talos 1.12+ emits multi-document machine config, and talhelper (plus `talosctl apply-config --config-patch`) do not accept RFC6902 JSON patches against multi-doc targets. This has blocked `task talos:generate-config` from succeeding since the Talos version bump:

```
failed to generate talos config: JSON6902 patches are not supported
for multi-document machine configuration
```

This PR converts the two remaining RFC6902 patches to Talos-native strategic-merge form so config generation works again. It also adds the now-required explicit bond `mode` to each bond definition.

## Changes

### Patch conversions

- **`patches/nvidia/nvidia-default-runtimeclass.yaml`**: `op: add /machine/files [array]` → `machine.files: [array]`.
- **`patches/controller/disable-admission-controller.yaml`**: `op: remove /cluster/apiServer/admissionControl` → `cluster.apiServer.admissionControl: {$$patch: delete}`. The `$$` escape prevents talhelper's variable substitution from trying to resolve `${patch}`.
- **`patches/global/containerd.yaml`**: unchanged. Its `machine.files[].op: create` is a Talos-native file-entry field, not an RFC6902 operation.

### Bond mode

Talos v1.13 rejects unset bond mode:

```
BondConfig/eth0: bond mode must be specified
```

Added explicit `mode: balance-rr` to all 8 bond definitions in `talconfig.yaml`. The live bond on cp-00 is running balance-rr per `/proc/net/bonding/eth0` (`Bonding Mode: load balancing (round-robin)`), so this makes the config explicit without changing behavior.

## Verified

```
$ task talos:generate-config
generated config for cp-00 in clusterconfig/home-kubernetes-cp-00.yaml
generated config for cp-01 in clusterconfig/home-kubernetes-cp-01.yaml
generated config for cp-02 in clusterconfig/home-kubernetes-cp-02.yaml
generated config for worker-00 in clusterconfig/home-kubernetes-worker-00.yaml
generated config for worker-01 in clusterconfig/home-kubernetes-worker-01.yaml
generated config for worker-02 in clusterconfig/home-kubernetes-worker-02.yaml
generated config for worker-03 in clusterconfig/home-kubernetes-worker-03.yaml
generated config for worker-04 in clusterconfig/home-kubernetes-worker-04.yaml
```

- All 8 configs generate successfully.
- Generated cp-00, cp-01, cp-02 are structurally identical (differ only in IPs / hostname).
- Generated worker configs are structurally identical.

## What this PR does NOT do

**No config is applied to any live node by this PR.** This PR only fixes the source patches and talconfig so that regeneration succeeds. Applying the regenerated configs is a separate manual step, planned as follow-up.

## Follow-up (NOT in this PR)

When applied later:
- `cp-00`: no-op (already matches).
- `cp-01`: DNS list refreshes from `[1.1.1.1]` (live drift) to `[192.168.0.2, 0.5, 0.6]` (from `patches/global/dns.yaml`). Brief resolv.conf refresh, no network blip.
- `cp-02`: interface reshape from `eno1` (standalone) → `eth0` (bond of `eno1`). Brief network blip during bond creation; VIP is on cp-00 so control-plane availability is unaffected.
- Workers: no-op (already match).

Applying to cp-02 is the immediate motivation — it clears the last drift blocking clean Multus enablement. Not applying to `worker-03` (defined but not currently in cluster).

## Blast radius

**Low for this PR** — only patch/config files. No cluster resources touched.

**Medium for the follow-up apply** to cp-02, in that reconfiguring a control-plane network creates a brief network blip. Mitigations:
- VIP already lives on cp-00.
- Cluster remains HA via cp-00 + cp-01 throughout.
- Only cp-02 network stack is touched.