### PR TITLE
feat(multus): enable Multus DaemonSet + NAD (Phase 1 of 2)

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
   - ./node-feature-discovery/ks.yaml
     #- ./nvidia-gpu-operator/ks.yaml
   - ./nvidia-device-plugin/ks.yaml
-    #- ./multus/ks.yaml
+  - ./multus/ks.yaml


### PR DESCRIPTION
## Summary

Phase 1 of the two-phase Multus rollout: enable the Multus DaemonSet and the `multus-net` NetworkAttachmentDefinition, WITHOUT enabling any consumer apps. Zero blast radius on running workloads because no pod annotation changes.

## What this PR does

Single-line change: uncomments `./multus/ks.yaml` in `kubernetes/apps/kube-system/kustomization.yaml` so Flux reconciles the two Multus Kustomizations that have been dormant since PR #1924:

| Kustomization | Purpose |
|---|---|
| `cluster-multus` | Deploys `kube-multus-ds` DaemonSet, `install-cni` init container, and the `NetworkAttachmentDefinition` CRD. `healthChecks` gate on DS readiness. `wait: true`. |
| `cluster-multus-networks` | Creates the `multus-net` NAD in `kube-system` (macvlan on `eth0`, IPAM host-local `192.168.6.1-50`, route `192.168.0.0/24 dev net1`). `dependsOn: cluster-multus`. |

## What this PR does NOT do

Consumer apps (`home-assistant`, `esphome`, `zwavejs`) keep their commented `# - name: cluster-multus-networks` `dependsOn` lines. Their pods:
- Are NOT restarted
- Do NOT get the `k8s.v1.cni.cncf.io/networks` behavior activated (that annotation exists on the pod template but Multus only acts on it when the pod is (re)created after Multus is running)
- Continue to run with just their Cilium primary interface

Consumer enablement is Phase 2 (follow-up PRs, one app at a time starting with esphome).

## Prerequisites verified live

- `kubectl -n kube-system get cm cilium-config -o jsonpath='{.data.cni-exclusive}'` → `false` ✓
- `flux -n flux-system get ks cluster-networking-cilium` → Ready=True ✓
- `kubectl -n kube-system get ds cilium` → 6/6 desired/current/ready ✓
- `talosctl -n <worker> list /etc/cni/net.d` → only `05-cilium.conflist` currently ✓
- Multus DS's `install-cni` init container (`ghcr.io/siderolabs/install-cni:v1.9.0`) will populate `/opt/cni/bin` with `macvlan`, `tuning`, etc. at DS startup ✓

## Post-merge verification (what I'll do after Flux reconciles)

```bash
flux -n flux-system get ks cluster-multus cluster-multus-networks
kubectl -n kube-system get ds kube-multus-ds
kubectl get networkattachmentdefinitions -A
talosctl -n 192.168.3.20 list /etc/cni/net.d      # should now show 00-multus.conf
talosctl -n 192.168.3.20 list /opt/cni/bin        # should now include macvlan, tuning
kubectl get pods -A | grep -v Running | grep -v Completed    # no new failures
```

Expected settling time: 2-3 minutes after Flux picks up the change.

## Blast radius

**Minimal.** Only new resources are created:
- New DaemonSet in `kube-system` (`kube-multus-ds`) — one pod per node, sidecar to Cilium
- New CRD (`network-attachment-definitions.k8s.cni.cncf.io`)
- New NAD (`multus-net` in `kube-system`)
- New ConfigMap for Multus config

No existing resource is modified. No existing pod is restarted.

## Rollback plan

Documented in `docs/multus-rollback.md` (PR #1963). Summary:

- **Level 1 (hands-free):** revert this PR on GitHub. Flux prunes the Multus resources. ~5-10 min recovery. Applies to any DS/NAD-related failure.
- **Level 2 (manual):** if `00-multus.conf` persists on nodes after DS removal, `talosctl rm /etc/cni/net.d/00-multus.conf` + restart Cilium agent pod per node.
- **Level 3-4:** covered in the runbook for edge cases.

Pre-rollout etcd snapshot has been taken:
```
~/etcd-snapshots/pre-multus-20260706-095419.snapshot
hash: c0eeeb3, revision: 695034084, keys: 8453, size: 584MB, format: 3.6.0
```
Validated with `etcdutl snapshot status`.

## Depends on

- PR #1963 (rollback runbook) — merge that first if it hasn't already landed.