### PR TITLE
feat(multus): enable esphome multus attachment (Phase 2a canary)

### DIFF
--- a/kubernetes/apps/home/esphome/ks.yaml
+++ b/kubernetes/apps/home/esphome/ks.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   dependsOn:
     - name: cluster-storage-longhorn
-    #- name: cluster-multus-networks
+    - name: cluster-multus-networks
   path: ./kubernetes/apps/home/esphome/app
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary

Phase 2a of the two-phase Multus rollout: enable the `cluster-multus-networks` dependsOn on `esphome`'s Kustomization as a single-pod canary. Home-assistant and zwavejs will follow in Phase 2b after this canary bakes for 15+ minutes.

## Verified Phase 1 state before opening this PR

- `cluster-multus` Kustomization: Ready=True on `main@sha1:724ab3d1` ✓
- `kube-multus-ds` DaemonSet: 5/5 desired = current = ready = available ✓
- `cluster-multus-networks` Kustomization: Ready=True ✓
- `NetworkAttachmentDefinition kube-system/multus-net` exists with correct spec (master eth0, /24 route) ✓
- `/etc/cni/net.d/00-multus.conf` present on worker-01 (verified via talosctl) ✓
- `/opt/cni/bin/{macvlan,tuning,multus-shim}` present on worker-01 ✓
- Consumer pods (esphome-0, home-assistant-0, zwavejs) unchanged and running ✓

## Why esphome first as canary

- **Single-pod StatefulSet** (`esphome-0`) pinned to `worker-01` via `nodeSelector: kubernetes.io/hostname: worker-01`. Predictable scheduling target.
- **Lowest blast radius**: if the macvlan attach fails, only esphome is affected. Its function (ESP device provisioning) is non-time-critical — no user is actively depending on it minute-to-minute like MQTT/HA would be.
- **Existing annotation**: esphome's helm-release.yaml has had `k8s.v1.cni.cncf.io/networks: kube-system/multus-net` on the pod template since PR #1924. Uncommenting the ks.yaml dependsOn is the last activation step.

## What this PR changes

One line: uncommenting `- name: cluster-multus-networks` in `kubernetes/apps/home/esphome/ks.yaml`.

## What happens automatically on merge

1. Flux reconciles cluster-home-esphome Kustomization
2. `dependsOn` now enforces cluster-multus-networks Ready gate (already True)
3. HelmRelease reconciles → produces no pod-spec change (only ks.yaml dependsOn changed, not pod template)
4. **The existing esphome-0 pod is NOT restarted by this PR**

## Post-merge manual step (required to activate net1)

To force a fresh pod that goes through Multus and gets `net1`:
```bash
kubectl --context=admin@home-kubernetes -n home delete pod esphome-0
```

## Verification after pod recreation

```bash
# net1 macvlan interface with IP in the multus range
kubectl -n home exec esphome-0 -- ip -o addr | grep net1
# expect: inet 192.168.6.<X>/24 ...

# routing table shows on-link + explicit route via net1
kubectl -n home exec esphome-0 -- ip route
# expect: 192.168.0.0/24 dev net1 ...
# expect: 192.168.6.0/24 dev net1 scope link ...
# expect: default via <cilium-gw> dev eth0 ...

# reach an ESP device on the physical LAN
kubectl -n home exec esphome-0 -- ping -c 3 <esp-device-ip>
```

## Blast radius

**Very low.** One-app scope; if this fails, only esphome breaks. Rollback via revert reverts esphome's ks.yaml one line; Flux re-reconciles esphome without the multus dependency.

## Rollback plan

- `docs/multus-rollback.md` Level 1 (hands-free PR revert) applies here
- Emergency fallback: `kubectl -n home delete pod esphome-0` to let esphome respawn without net1 (works because ks.yaml is only the reconcile-time gate; pod re-creation uses whatever the current NAD state is)

## Follow-up

- Phase 2b PR: enable dependsOn for `home-assistant` and `zwavejs` (after this canary verifies for 15+ min)