### PR TITLE
feat(multus): enable multus for home-assistant + zwavejs (Phase 2b)

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helm-release.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helm-release.yaml
@@ -177,5 +177,3 @@ spec:
           - hosts:
               - *host2
             secretName: *host2
-    podAnnotations:
-      k8s.v1.cni.cncf.io/networks: macvlan-static-iot-hass

--- a/kubernetes/apps/home/home-assistant/ks.yaml
+++ b/kubernetes/apps/home/home-assistant/ks.yaml
@@ -11,7 +11,7 @@ spec:
   dependsOn:
     - name: cluster-storage-longhorn
     - name: cluster-databases-postgres-clusters
-    #- name: cluster-multus-networks
+    - name: cluster-multus-networks
   path: ./kubernetes/apps/home/home-assistant/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/zwavejs/ks.yaml
+++ b/kubernetes/apps/home/zwavejs/ks.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   dependsOn:
     - name: cluster-storage-longhorn
-    #- name: cluster-multus-networks
+    - name: cluster-multus-networks
   path: ./kubernetes/apps/home/zwavejs/app
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary

Phase 2b of the Multus rollout: enable `cluster-multus-networks` dependsOn on home-assistant and zwavejs, completing consumer enablement after Phase 2a esphome canary verified.

## Phase 2a mDNS causation proof (from the esphome soak)

Before opening this PR, we causally proved macvlan/net1 is required for mDNS discovery by temporarily removing esphome's multus annotation:

| State | ESPHome dashboard says |
|---|---|
| With `net1` (multus attached) | `mDNS active`, live MAC/version/hash |
| Without `net1` (multus annotation removed) | `MQTT active` only, warns "reachable over MQTT but not via mDNS ... dashboard and the device are on different subnets", flags device data as stale |
| Restored `net1` | Back to `mDNS active` |

The dashboard's own error message stated the reason: "dashboard and the device are on different subnets" — exactly what happens with only Cilium's `10.69.6.0/24` overlay vs. ESP devices on `192.168.0.0/24`.

## Changes

- **`kubernetes/apps/home/home-assistant/ks.yaml`**: uncomment `- name: cluster-multus-networks` in dependsOn.
- **`kubernetes/apps/home/zwavejs/ks.yaml`**: same.
- **`kubernetes/apps/home/home-assistant/app/helm-release.yaml`**: remove dead code at `spec.values.podAnnotations` that referenced a nonexistent NAD `macvlan-static-iot-hass`. The active multus annotation is at `spec.values.defaultPodOptions.annotations` and is unchanged.

## Verified pod annotations are already present

Both HA and zwavejs helm-release.yaml files already have `k8s.v1.cni.cncf.io/networks: kube-system/multus-net` on the pod template (from PR #1924). This PR just activates the Flux dependsOn gate; the annotation was waiting for the NAD to exist (Phase 1 landed that).

## Post-merge manual steps

The dependsOn change alone does NOT restart existing pods. To activate `net1` on both consumer pods, run after merge:

```bash
kubectl --context=admin@home-kubernetes -n home delete pod home-assistant-0
kubectl --context=admin@home-kubernetes -n home delete pod -l app.kubernetes.io/name=zwavejs
```

## Post-verification for each pod

```bash
# net1 macvlan interface present with 192.168.6.x/20 IP
kubectl -n home get pod <name> -o jsonpath='{.metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}'
# expect two entries: cilium eth0 + kube-system/multus-net net1

# For home-assistant: check mDNS multicast subscription
kubectl -n home exec home-assistant-0 -c home-assistant -- cat /proc/net/igmp | head -20
# expect: net1 subscribed to FB0000E0 (224.0.0.251, mDNS)

# Physical LAN reachability
kubectl -n home exec home-assistant-0 -c home-assistant -- ping -c 3 -W 2 <known-mDNS-device-IP>
```

## Blast radius

**Low.** Two-app scope. The dependsOn change only affects when Flux gates future reconciles; existing pods keep running with their current attachments until manually deleted. If manual pod deletion causes issues, the rollback path is simple: revert PR and delete pods again (they respawn with pre-multus state).

## Rollback

`docs/multus-rollback.md` Level 1 (revert this PR). Additional consideration:
- After revert, delete the pods again to get them off Multus and back to Cilium-only.
- IP collisions from the shared 192.168.6.1-50 pool are noted in the NAD TODO — currently unlikely because HA and zwavejs are scheduled on distinct nodes (worker-01 and workers with the zwave NFD label respectively), but worth watching first startup.

## Follow-up

- Optional: run `/analyze` on the cluster to confirm no other apps have dead multus annotations pointing at nonexistent NADs.
- Track: shift host-local IPAM to whereabouts if we add a 4th multus consumer or if consumer node-pinning ever loosens.