### PR TITLE
chore(zwavejs): remove multus attachment (RF, not Ethernet)

### DIFF
--- a/kubernetes/apps/home/zwavejs/app/helm-release.yaml
+++ b/kubernetes/apps/home/zwavejs/app/helm-release.yaml
@@ -30,8 +30,6 @@ spec:
     keepHistory: false
   values:
     defaultPodOptions:
-      annotations:
-        k8s.v1.cni.cncf.io/networks: kube-system/multus-net
       nodeSelector:
         node-role.kubernetes.io/worker: 'true'
 #        aeotec.feature.node.kubernetes.io/zwave: "true"

--- a/kubernetes/apps/home/zwavejs/ks.yaml
+++ b/kubernetes/apps/home/zwavejs/ks.yaml
@@ -10,7 +10,6 @@ metadata:
 spec:
   dependsOn:
     - name: cluster-storage-longhorn
-    - name: cluster-multus-networks
   path: ./kubernetes/apps/home/zwavejs/app
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary

Removes the Multus `net1` attachment from zwavejs. Z-Wave devices communicate over 900MHz RF radio via the USB serial dongle — nothing in zwavejs uses Ethernet broadcast domains (mDNS, SSDP, etc.), so the macvlan interface was unused dead weight.

## Why zwavejs never needed Multus

Multus (macvlan/net1) provides:
- L2 broadcast reachability to physical LAN devices (mDNS, SSDP, ARP)
- Direct routing to `192.168.0.x` devices without going through Cilium's overlay

Z-Wave JS UI needs neither:
- **Device I/O**: Z-Wave devices talk to the app via the USB dongle (`/dev/ttyUSB0`), which is a Talos hostPath mount — networking is not involved
- **App I/O**: HA reaches zwavejs via ClusterIP (unicast TCP over Cilium); browsers reach it via Traefik ingress (also Cilium); MQTT publishes go to Mosquitto's Service DNS

## Verified live before this PR

```
$ kubectl -n home exec zwavejs-xxx -- cat /proc/net/igmp
# ...no FB0000E0 (mDNS) or FAFFFFEF (SSDP) subscriptions on net1 or eth0

$ kubectl -n home exec zwavejs-xxx -- cat /proc/net/tcp6 | grep 0A
# Only wildcard :: listens on ports 8091 (UI) and 3000 (WebSocket) — accepts
# on any interface but no protocol requires physical LAN broadcast

$ kubectl -n home get pod zwavejs-xxx -o jsonpath='...'
# net1 attached with IP 192.168.6.16 — completely idle
```

## Changes

- `helm-release.yaml`: remove `k8s.v1.cni.cncf.io/networks: kube-system/multus-net` annotation
- `ks.yaml`: remove `- name: cluster-multus-networks` from `dependsOn`

## Blast radius

**Zero.** Z-Wave device operation is unchanged — dongle communication doesn't touch the network stack. HA → zwavejs communication uses ClusterIP (Cilium primary interface), also unchanged.

## Post-merge

Force fresh pod without `net1`:
```bash
kubectl --context=admin@home-kubernetes -n home delete pod -l app.kubernetes.io/name=zwavejs
```

## Benefits

- Frees up a `192.168.6.x` IP from the shared host-local IPAM pool (reduces collision risk documented in the NAD TODO)
- Cleaner manifest — no dead attachments
- One fewer place for future readers (human or AI reviewer) to wonder "why does zwavejs need macvlan?"

## Rollback

`docs/multus-rollback.md` Level 1 (revert this PR). Trivial — restores the two lines and re-runs the pod-delete cycle.