### PR TITLE
fix: paperless NFS path, redis-lb cleanup, traefik chart 41.0.2

### DIFF
--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -34,33 +34,52 @@ jobs:
           ref: "${{ github.event.repository.default_branch }}"
           path: default
 
-      # Workaround for a known false positive on Authelia HelmRelease templating.
-      # flux-local cannot decrypt SOPS secrets, so ${SECRET_..._OAUTH_CLIENT_SECRET_HASHED}
-      # substitutes to an empty string, which Authelia's chart validator rejects
-      # ("must have a hash prefix"). This blocks every Authelia PR from ever getting a
-      # green helmrelease diff. The Kustomization diff (matrix.resources=kustomization)
-      # is unaffected and still runs, providing the actionable resource-level diff for
-      # reviewers. Adjacent checks (Kubeconform, workstation e2e) also validate the
-      # HelmRelease shape. See README-LLM.md → "Known CI limitations" for full details.
+      # Workaround for known false positives in flux-local's helmrelease templating.
+      # flux-local (running in a Docker image) cannot decrypt SOPS secrets, and it
+      # cannot install cluster CRDs before rendering. Two classes of chart trip on
+      # this:
       #
-      # This step removes Authelia from both checkouts ONLY for the helmrelease matrix
-      # leg, so flux-local's template phase never sees it and cannot fail on it.
-      - name: Strip Authelia (helmrelease diff only, known SOPS/validator false positive)
+      #   - Authelia: `${SECRET_..._OAUTH_CLIENT_SECRET_HASHED}` substitutes to ""
+      #     -> Authelia's chart validator: "must have a hash prefix" -> hard fail.
+      #   - Traefik: chart references `monitoring.coreos.com/v1` ServiceMonitor CRD
+      #     which flux-local doesn't install first -> "You have to deploy
+      #     monitoring.coreos.com/v1 first" -> hard fail.
+      #
+      # The Kustomization diff (matrix.resources=kustomization) is unaffected and
+      # still runs, providing the actionable per-resource diff for reviewers.
+      # Adjacent checks (Kubeconform, workstation e2e) also validate the HelmRelease
+      # shape. See README-LLM.md → "Known CI limitations" for full detail.
+      #
+      # For each app in the exclusion list below, we strip the app tree from both
+      # checkouts (pull/ and default/) ONLY for the helmrelease matrix leg, so
+      # flux-local's template phase never sees it and cannot fail on it. The parent
+      # namespace kustomization.yaml has the app's `./<app>/ks.yaml` line removed
+      # via sed so the parent Kustomization still builds cleanly.
+      - name: Strip helmrelease-diff-incompatible apps (known flux-local false positives)
         if: ${{ matrix.resources == 'helmrelease' }}
+        env:
+          # Format: `namespace/app-name` — the paths under kubernetes/apps/
+          EXCLUDED_APPS: |
+            networking/authelia
+            networking/traefik
         run: |
           set -euo pipefail
-          for root in pull default; do
-            authelia_dir="$root/${{ matrix.paths }}/apps/networking/authelia"
-            authelia_ks_ref="$root/${{ matrix.paths }}/apps/networking/kustomization.yaml"
-            if [ -d "$authelia_dir" ]; then
-              echo "Removing $authelia_dir"
-              rm -rf "$authelia_dir"
-            fi
-            if [ -f "$authelia_ks_ref" ]; then
-              echo "Removing ./authelia/ks.yaml reference from $authelia_ks_ref"
-              # Delete the resource entry so networking kustomization still builds
-              sed -i '/^\s*-\s*\.\/authelia\/ks\.yaml\s*$/d' "$authelia_ks_ref"
-            fi
+          echo "$EXCLUDED_APPS" | while IFS= read -r app_path; do
+            app_path="$(echo "$app_path" | tr -d '[:space:]')"
+            [ -z "$app_path" ] && continue
+            app_name="${app_path##*/}"
+            for root in pull default; do
+              app_dir="$root/${{ matrix.paths }}/apps/$app_path"
+              parent_ks="$root/${{ matrix.paths }}/apps/${app_path%/*}/kustomization.yaml"
+              if [ -d "$app_dir" ]; then
+                echo "Removing $app_dir"
+                rm -rf "$app_dir"
+              fi
+              if [ -f "$parent_ks" ]; then
+                echo "Removing ./$app_name/ks.yaml reference from $parent_ks"
+                sed -i "\|^\s*-\s*\./$app_name/ks\.yaml\s*\$|d" "$parent_ks"
+              fi
+            done
           done
 
       - name: Diff Resources

--- a/README-LLM.md
+++ b/README-LLM.md
@@ -510,51 +510,62 @@ For Authelia specifically — the chart (`version`) and image (`tag`) are versio
 
 ## Known CI limitations
 
-### Flux Diff (kubernetes, helmrelease) fails on any PR touching Authelia values
+### Flux Diff (kubernetes, helmrelease) false positives
 
-**Symptom:** A CI check named `Flux Diff (kubernetes, helmrelease)` fails with:
+The `Flux Diff (kubernetes, helmrelease)` check has multiple known false-positive failure modes rooted in `flux-local`'s architecture: it runs in a stock Docker image with no cluster context, cannot decrypt SOPS by design, and cannot install cluster CRDs before rendering helm templates. Charts that assume either substituted secrets or pre-installed CRDs will hard-fail `helm template` in CI even though they work fine in production.
+
+The workflow (`.github/workflows/flux-diff.yaml`) maintains an `EXCLUDED_APPS` list that removes known-incompatible apps from the `helmrelease` matrix leg only. The `kustomization` matrix leg still runs on those apps and produces the actionable per-resource diff for reviewers.
+
+**Currently excluded apps and why:**
+
+#### Authelia (`networking/authelia`) — OIDC `client_secret` validation
 
 ```
 Error: execution error at (authelia/templates/validations.configMap.check.yaml:99:3):
 The value 'secret.value' for the 'configMap.identity_providers.oidc.clients'
-must have a hash prefix. At this time the '$plaintext$' prefix is still accepted
-however we recommend taking the opportunity to properly hash it as the plaintext
-variants will only be accepted in the future for the 'client_secret_jwt'
-authentication method.
+must have a hash prefix.
 ```
-
-**Why it happens:**
 
 1. The Authelia HelmRelease has an `identity_providers.oidc.clients` list where each entry's `client_secret` is a Flux variable placeholder like `${SECRET_TAILSCALE_OAUTH_CLIENT_SECRET_HASHED}`.
 2. In production, Flux substitutes these from the SOPS-encrypted `cluster-secrets` Secret at reconcile time. The real values are already-hashed strings (e.g. `$argon2id$v=19$...`) that pass Authelia chart's built-in validator.
-3. In CI, the `Flux Diff` workflow runs `flux-local diff helmrelease` from a Docker image against the checked-out repo. `flux-local` **cannot decrypt SOPS** by design (documented behavior — no access to the age private key). So it substitutes the placeholders with **empty strings**.
+3. In CI, `flux-local diff helmrelease` runs from a Docker image against the checked-out repo. `flux-local` **cannot decrypt SOPS** by design (documented behavior — no access to the age private key). So it substitutes the placeholders with **empty strings**.
 4. `flux-local` then runs `helm template` on the Authelia chart with empty-string `client_secret` values. Authelia's chart validator sees no `$argon2id$` / `$plaintext$` prefix and hard-fails the template step.
-5. The workflow step exits non-zero → check is red.
 
-**Impact:** None on runtime. Real cluster is unaffected — production has the real hashed secrets. The failing CI check is a false positive specific to `flux-local`'s inability to decrypt SOPS.
+#### Traefik (`networking/traefik`) — ServiceMonitor CRD not installed
 
-**Adjacent checks that still work correctly:**
+```
+Error: execution error at (traefik/templates/servicemonitor.yaml:5:10):
+ERROR: You have to deploy monitoring.coreos.com/v1 first
+```
+
+The Traefik chart renders a `ServiceMonitor` resource which requires the Prometheus Operator's `monitoring.coreos.com/v1` CRD. `flux-local`'s helm-template environment has no cluster CRDs installed, so the render aborts. Added to the exclusion list in the same PR that bumped Traefik to chart 41.0.2.
+
+**Adjacent checks that still work correctly for excluded apps:**
 - `Flux Diff (kubernetes, kustomization)` passes and its auto-comment on the PR shows the exact final resource diff that will be applied to the cluster
 - `Kubeconform` passes (validates YAML shape against Kubernetes schemas)
 - `workstation (archlinux|generic-linux)` pass (e2e validation of workspace bootstrap)
 
 **Historical context:**
-- Commit `e2dc2f2c` ("fix(authelia): revert helm-release values changes to unblock Flux Diff CI") is a partial workaround: it reverts non-essential Authelia edits so `flux-local` sees "no change" and skips re-templating Authelia. Only works for PRs that don't intentionally touch Authelia's values.
+- Commit `e2dc2f2c` ("fix(authelia): revert helm-release values changes to unblock Flux Diff CI") is a partial workaround: it reverts non-essential Authelia edits so `flux-local` sees "no change" and skips re-templating Authelia. Only works for PRs that don't intentionally touch Authelia's values. Superseded by the exclusion list.
 - `flux-local` itself is deprecated (see the workflow's warning banner). Upstream recommends migrating to [`flate`](https://github.com/home-operations/flate) / [`konflate`](https://github.com/home-operations/konflate), which may or may not have the same limitation — not investigated yet.
 
-**Options to fix (none applied yet):**
-1. **Wire real SOPS decryption into CI.** Store the age key as a `SOPS_AGE_KEY` GitHub Actions repo secret. Add a pre-`flux-local` step that runs `sops -d` in-place on the checked-out repo. Same trust model as production Flux; decrypted files live only on the ephemeral runner. Standard pattern for fleets doing SOPS + flux-local CI.
-2. **Throwaway age keypair + dummy hashed secrets.** Create a separate age keypair used only for CI. Encrypt a stripped-down `cluster-secrets` file with placeholder hashed values (e.g. `$plaintext$dummy` for every `SECRET_*_OAUTH_CLIENT_SECRET_HASHED` key). Store the throwaway key as a GitHub Actions secret. Never touches real cluster secrets.
-3. **Exclude Authelia from `Flux Diff (helmrelease)`.** Simplest patch: strip `kubernetes/apps/networking/authelia/**` (or the whole `networking/authelia` Kustomization file) from the `pull/` and `default/` checkouts before invoking `flux-local`. Loses CI coverage for Authelia HelmRelease changes but every other check still validates them.
-4. **Migrate off `flux-local` to `flate`/`konflate`.** Larger scope. Would need to investigate whether the newer tools handle this case.
+**Proper fixes (none applied yet — the exclusion list is the pragmatic patch):**
+1. **Wire real SOPS decryption + CRD installation into CI.** Store the age key as a `SOPS_AGE_KEY` GitHub Actions repo secret. Add a pre-`flux-local` step that runs `sops -d` in-place, and install the Prometheus Operator CRDs into the runner. Same trust model as production Flux; decrypted files and CRDs live only on the ephemeral runner.
+2. **Throwaway age keypair + dummy hashed secrets.** Create a separate age keypair used only for CI. Encrypt a stripped-down `cluster-secrets` file with placeholder hashed values. Store the throwaway key as a GitHub Actions secret. Never touches real cluster secrets. Doesn't help the CRD case.
+3. **Migrate off `flux-local` to `flate`/`konflate`.** Larger scope. Might handle both cases better; needs investigation.
+
+**Adding a new app to the exclusion list:**
+
+1. Confirm the failure is a false positive, not a real chart error. Look at the log — if it's a value-substitution or CRD-missing error, likely false positive. If it's a genuine templating error (typo in values, missing required field, etc.), fix the manifest instead.
+2. Edit `.github/workflows/flux-diff.yaml`, add the app's `namespace/app-name` path to the `EXCLUDED_APPS` list env var in the "Strip helmrelease-diff-incompatible apps" step.
+3. Add a subsection to this README-LLM section explaining which chart and why.
 
 **When reviewing a PR:**
 
-If `Flux Diff (kubernetes, helmrelease)` is the *only* failing check and the PR touches Authelia (`kubernetes/apps/networking/authelia/**`), it is almost certainly this known false positive. Verify by reading the workflow log for the `hash prefix` error. Do not spend cycles debugging the substitution — it will render correctly in the cluster.
-
-If a PR touches Authelia and `Flux Diff (kubernetes, kustomization)` is *also* failing (or any other check), that is a real issue and must be investigated.
+If `Flux Diff (kubernetes, helmrelease)` is the *only* failing check and the PR touches an app in `EXCLUDED_APPS`, it is almost certainly the known false positive. Verify by reading the workflow log for the specific error message. If any other check is also failing, it is a real issue and must be investigated.
 
 ---
+
 
 ## SOPS / Secrets Reference
 

--- a/kubernetes/apps/home/dawarich/app/secret.sops.yaml
+++ b/kubernetes/apps/home/dawarich/app/secret.sops.yaml
@@ -4,18 +4,18 @@ metadata:
     name: dawarich
     namespace: home
 stringData:
-    DB_ENGINE: ENC[AES256_GCM,data:zUW+8VpspxgPMA==,iv:AHdFSDYfvIpAFlOF+lGrnrFmaqME5GC4c5ChyWkwXMM=,tag:5klmL4kGktePaaz4Pq9R8w==,type:str]
-    DB_NAME: ENC[AES256_GCM,data:XvXzPv5Cboo=,iv:c7LFCDBEAbIjDq8DCLfHSLyT9uGoPrdCcEH7gTow0T0=,tag:cr6pPWAZgLwN4WWX70w2NQ==,type:str]
-    DB_USER: ENC[AES256_GCM,data:nwhUJrcuzX4=,iv:hrGrnryiNhc4yc+VsvP0MsYwxUHh/vr30P1FHeRUEFM=,tag:SDLwhUaFMYlmlu7brWhBnw==,type:str]
-    DB_PASSWORD: ENC[AES256_GCM,data:fcORL/pyeDJHx2jf4z+tXzGc31bNevzMFlYgRIgTwKWFD6TA0DJdTvuzkViHiBfATxKaHE0JbW7ZaLBTce6vMw==,iv:DRqqXQeK+jgoYXMZzhL7ttzB7N8CnX49HfXhyoX3MMM=,tag:zRW0QYWWTSMGMXlg2PX1jQ==,type:str]
-    DB_HOST: ENC[AES256_GCM,data:nzUGOlvhUiGiAk4EF7Dthaf3Z0k27ysSJBOWvnvKSoTI/dtAO6bAElE00nt0fv4=,iv:WlWi0Gaq+iM0J0cYMH2gVoGwRQX/0tUCseSqcgaX7jY=,tag:N/h+kaPmxGSDGht1qL+nfQ==,type:str]
-    DATABASE_HOST: ENC[AES256_GCM,data:MiCq9yRE54fp/9khL1jva90QRf98hgcTz1ro67koMvg0vzNytxAa2ksMCxFvpH8=,iv:id8zbfFmDL0OW2aIiLfG3WoZ6fQsgy/HQsUyi5QQ+Vw=,tag:dvuZVp4M6bX/iDBexZHIFw==,type:str]
-    REDIS_URL: ENC[AES256_GCM,data:tXhsoAPntmzvBeGcFvpYtMv3N4JtPiO7I9jacLK9vCGB7OO6cozzQuN1MtAZ07Hww2Gw7Q/LwL/3lFBEBBKwwI8EjA==,iv:bv55sHavN25j+H3KGr/e0WO6KhSE6ywge5yGVlLFjjA=,tag:FhDrU5NwGxnUtR66OmH5Gg==,type:str]
-    APPLICATION_HOSTS: ENC[AES256_GCM,data:xKHSV1secZVpaIHy70xI9BFnl/payiCPxaDSVRKOH1coTkOoy8jHpg2imFBOJSKJ53BgkA==,iv:WLUXwbNHjeYO74knNcux234qRSCruQJxpF9f3DYiryw=,tag:jpdTzhuzs9THN03hkkIQTQ==,type:str]
-    APPLICATION_PROTOCOL: ENC[AES256_GCM,data:bd0qs00=,iv:p5xNB7UMfNLt+vmVZWnT28uFoQ4zlWZBE7w06/Oqd7M=,tag:hsX6HOkqWp1OBr5qg48MNw==,type:str]
-    SECRET_KEY_BASE: ENC[AES256_GCM,data:uVVKU303IKs6IXCQnITpHXQjzp7303nKg4s0sSl1i67jo5c7TuWhnjBsKMwe5dUxBIDB16yfnX6NDBIGlKZR+A==,iv:Fq0wg18QjX9jyfptrAIkWpcGKB4X88Uq5hk/tStS9fE=,tag:1fWp8hMjQ+04byG2y2mj0Q==,type:str]
-    OIDC_CLIENT_ID: ENC[AES256_GCM,data:Ql26SZQI6AQ=,iv:MRyQ5MNfvA0b4FojQV6L6HDPcpfpl3TnZkvTQFSw4wc=,tag:AqXxYKrXYPvwwxD0VNyb/A==,type:str]
-    OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:rdq/f5MaND873B4Rl/ogm0pF76qrFPwU40pf/NYOwbYfc17WxzU=,iv:L38x+s28NP58RlETy60YzcfW09ew05AtvwGXecS0SvE=,tag:SwYuQVL+bqetQasnpbH+Pg==,type:str]
+    DB_ENGINE: ENC[AES256_GCM,data:VdA1OJ7x2SkH/A==,iv:Wfd1/DS36kpG0PDNqCxW6KZmaRjCt/XFd6H4z7nlv54=,tag:kEmI/Rl9iNwAB5wdKAM9Ig==,type:str]
+    DB_NAME: ENC[AES256_GCM,data:1N2TztXENVU=,iv:ttOfZ5ueQKFnWWmR6nipgcMlVbK4vhl0XetM9/5WEYk=,tag:6gs4QMSCzr/BpTYoOupXfw==,type:str]
+    DB_USER: ENC[AES256_GCM,data:bc7SDSSsKlA=,iv:Lx+QFMEl5et5L8TkC46rBZ6EiW8c5eBmHCH7qmaYt2U=,tag:+/Tux5o8FLb/QswXYIzJKA==,type:str]
+    DB_PASSWORD: ENC[AES256_GCM,data:6c87J++q57H2xVcKj+RysREmtJUvjpHa2UECwE34r8S1anHXJOzQkfGUAohTlXRKXF8lZg0KJF1TiQpv3Q30IA==,iv:fGSy2QDPkGqpxkas6fF2N2m1IlIHDBfE0XzuFltjpB8=,tag:oi4062JhqgM9Hb0dIaAGWg==,type:str]
+    DB_HOST: ENC[AES256_GCM,data:B6Y0LXNB8m5KQDGLw+1Kv97rv0dF6d43qDXhNXPrdlkDmHJFfM4pjTMHFaiAxqA=,iv:G9kiHofwHS2loZppqtRxy8sL3TD2TIAryyCW4nD24OY=,tag:Y3xkG4T8HTtxemCYVF2eog==,type:str]
+    DATABASE_HOST: ENC[AES256_GCM,data:+D7Ajh/gIBCKWxp4ht6S2QK3R6Y1Tp5wFVvHxa6Nm+o3ZLKzWWLdNI3b7ZSD0WY=,iv:VFgszmwBzzsThxDvM0iw3+KOQdflWyhCgJ5L+6gu4E8=,tag:h2ik4dNe2yRdgAsqyxlCuA==,type:str]
+    REDIS_URL: ENC[AES256_GCM,data:jE4qsyeWEitdYaFZT7UnfLX3CMFwIew3Em5IAD8hsk8lcryHM8Fnr1zsgSKwEz4TXeeobPpgeliUrpdC5q+Cl7w9HrK7hKk3,iv:5xM6/tjwnYR5aSqzMZvM+Rwfo7K9RMjzc1vIonxcjpg=,tag:LmuW1cLqLNILgds44lhnww==,type:str]
+    APPLICATION_HOSTS: ENC[AES256_GCM,data:N9cXwahlaZC9Fy9Q8r6yQnPT41F2YRJ720di5f9UCI33syLszwroZDXH2H5FDGNXa386+w==,iv:oRv0R2n/J3X9ZY4U4d1n/nJH9CLLx6Bc6Is8zH7ggWA=,tag:KzPqnxTz+qMZc5CGqlUHbw==,type:str]
+    APPLICATION_PROTOCOL: ENC[AES256_GCM,data:z2ceLHg=,iv:BVMbXMp26PAT5CQG8xGXgLk/AmmVASn0UDg67LXDSgg=,tag:p/ogT3FJ2DspxbyoKk+1hQ==,type:str]
+    SECRET_KEY_BASE: ENC[AES256_GCM,data:ie9MRgqAD/NvIrfKechw4NZEsacg36y+T8TEmtbrJZs87CETFKo8C3i3fgAFMsMXvKMgWpVHcyJOD8UdDkOU2Q==,iv:bx/ptt9w3l2xlGj8i7Mw8c+XBIJTX9fz2QBFaO+XPeI=,tag:wl8nySGIoBK/ttS3kaisFw==,type:str]
+    OIDC_CLIENT_ID: ENC[AES256_GCM,data:OaHTYSOAx8k=,iv:ZCL65QYHtczuoOKfvuoumhar6anv1dLW49hjlXZXZp8=,tag:vOCUnzkRgg8u/3HEOmNKXA==,type:str]
+    OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:RG4pIzuXlbDb9DAGiQtkJcRXiKMjE0Z/0uBh9NfM11Ys7dPOtUQ=,iv:aHAbEtFbAWshSTxEbAYuMqUI+LR4pH3pa68ST0pko4Y=,tag:SyIRiEvFHI0Te3vYWetcJg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -25,14 +25,14 @@ sops:
         - recipient: age1rr569v9jm7ck70q4wpnspfhdvt4y5m6s604tx0ygs0a65qkt7g4qdszk6k
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0bnZ0THJCVnM4cWI1b3l6
-            ZjZrT0hJSlkycnl1NXVVOWFLNTB4aE44RlFnCkwvVGhtZU5qek5UU09RUHg0SHNt
-            SlRPWm1uWllCMlVFN1FlcFdTanJKWlUKLS0tIDhOc25uNnBocGZpOFBuVTlnZHgr
-            bW9qc1Bna2hwODJiYmNzWUE3dGFGUUkKN9gwhoXq/BzGfoLe3gfT3PzUQUHSAeLo
-            ZQFAGDN1lWh13lPgj6xvzOeI6ueH9+iYWWFYhOyvXR9fWpR5kMoXBA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaK3g3bUFkaWkxMUhpdEJi
+            dTFmMnpTWVlHWVpVL1EwbTNMVTNORHVOd0VVCk51aG1Yd2VsNGxTQ3dnSXhnYWJF
+            RUdycmhGWW1WVlNTTDcxNlZBY0lwUEkKLS0tIHlMR09vT0RYRlVIN2poM2dlaUdq
+            NVNCdDQ3R2dlZ3lNVC9tOVZMaCswZFEKB6gekK9sfn5RJ6P7IAeoKVvDfvVk7EOq
+            S1RH2o0tNGuVOARnBJArF5GZ/oaKc5Ei8ol5qHiuQpvQKST4r+Pd7A==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-19T06:36:36Z"
-    mac: ENC[AES256_GCM,data:8pSh0q6OxRaYVptoW/Iz7m4tf4qYXzt3ce6t375+a2wVRfTtXxieemkiyU+V2LEpg/KKDnGd77UQ3GHKkTBPR5eF3YoLhqBumtRhsUnolHKNNvgIf3/6yH97/GwmHneeamUTMUIlzFvdc/jGtQN0oAubnlxAvi5w/luIydfErn0=,iv:eBeWb7gcIB9EPNgmlBWX+nzIsaVOntrXXRHXzAvUvnc=,tag:aO/cZAMC6vgy7vo0lmXiKA==,type:str]
+    lastmodified: "2026-07-07T01:00:19Z"
+    mac: ENC[AES256_GCM,data:XDZ+QiT7QoESeoiupt0JGcfRBcJ1KIGtFoKQK7LZmrUjzst299jYg5n/jnr2DrQM4NDvjO4jqe2I9SpbmbeE/53L8Rpwsa9v5Nqs16oY8/UoKWs+KJWDgkoTJkx60EKzj34m1OA5RxGAlwEC4WBAyc27d1dHKWTevtY/7vTo+NY=,iv:CkiZQzgcZPjNirnYIduddSuC4SsXHQIGXuAb9/AWFWI=,tag:EQCQM4Z+i4RzNgbZxCEosg==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.1
+    version: 3.9.4

--- a/kubernetes/apps/media/immich/app/secret.sops.yaml
+++ b/kubernetes/apps/media/immich/app/secret.sops.yaml
@@ -5,14 +5,14 @@ metadata:
     name: immich
     namespace: media
 stringData:
-    DB_HOSTNAME: ENC[AES256_GCM,data:jxdebMN/aPcgJdj+CFtUmV7M8UJ4DThEqB8kYdXNIlzJou6fZts9,iv:aIUYwraKsQHXL/foN4Xph45CzD/g+jr/iU5S6wOT268=,tag:P1U5PktUl69V4lANY7eLdw==,type:str]
-    DB_PORT: ENC[AES256_GCM,data:q1cePw==,iv:wc+H4kYFmeVbQFECEgrCb0CjXwz0sHCftgCEWksk+bk=,tag:vWBSSIIv7KT1VTxmhkAw3g==,type:str]
-    DB_DATABASE_NAME: ENC[AES256_GCM,data:FUGpiF4L,iv:cXvU6f1xAwuzBx+eowdXlk0qMAEmhhWK8sDhoiqHWWw=,tag:yKN7pxGKnwAcq3VcVWeTyQ==,type:str]
-    DB_USERNAME: ENC[AES256_GCM,data:YwnBM1Cb,iv:2L/T4glZvDvv5cXoi/J2yyQe2+CbCHRzE6xBaAdtLts=,tag:G34xBxExYnxC5IM6Wk8Wig==,type:str]
-    DB_PASSWORD: ENC[AES256_GCM,data:PpMjL7+FWNgndM4M+UeEM4ww9Afp+ZM=,iv:o2uyLj276vUcB62EgVY0o8mxzi9uPPTO6AhqMNE7I4k=,tag:1G0IKZ5mn8lplleqVc0kkg==,type:str]
-    REDIS_HOSTNAME: ENC[AES256_GCM,data:XAjkLaBjmwpvXzOJeGjA+IUq9/py1WcJinvfrq/0eecjDuhH,iv:R5MnUQ8tMxwq7LTyGQ+qZDmOByBy141TmQo9RooX4XE=,tag:2pmr/DsQbZYgEGEjW0kSlQ==,type:str]
-    REDIS_PORT: ENC[AES256_GCM,data:ACAPOw==,iv:Em5V+acjAzcvElLWrl+mOOEOvxhnTFtYi4dTYp7dM1U=,tag:/oXhyheds2hxHt1zxFy9/w==,type:str]
-    OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:n+WObeCB4JUdf+Tj2foBPJSCIbUfBF/l7hmEgpFxPgvlYDLq,iv:gsBfJ1D+Egb8Gz1Fw0u826fuuP1LeoMTY+G52Q1V6cE=,tag:y4CrFIEXvZGoWHxVhctdyA==,type:str]
+    DB_HOSTNAME: ENC[AES256_GCM,data:HuEnU9SgEWjdzVX3EGlxxfQTTaaXLdeMpSWFt05wC0EAU/7Z7csD,iv:0dlSKzJsdeBryRI7yDu+/6QwkTV9oY4Sy5RWdgZkesI=,tag:3dOCD4bVXaA7Wwl3t2jA6g==,type:str]
+    DB_PORT: ENC[AES256_GCM,data:hgGcnA==,iv:14MqcNQhAeJUzp19n3d3gBxuJrFy+p6O10oOejRRbfA=,tag:W72tcvBI+Cbt4+MNKpEbSw==,type:str]
+    DB_DATABASE_NAME: ENC[AES256_GCM,data:wyHS+GxX,iv:SdaxaQKzTj1ZV3Yf5g3/G9wi1YKrdzWHK1SnN3LZ11U=,tag:eeq+oHZw3am0pTnzt4eqcA==,type:str]
+    DB_USERNAME: ENC[AES256_GCM,data:wM9x6Uot,iv:uatlvQpoGgoqS0X3VOBo7v3YJ1qyaI9lm1YLtaFBC90=,tag:hTorAMeeJp1ba3t8YYEG2w==,type:str]
+    DB_PASSWORD: ENC[AES256_GCM,data:LbGOSIEB+UCht+dQ/D8wxkBNW06GGVQ=,iv:ElSWa46w0E3VhLMJU19MAUchNAD/ibcftanQ6aIndOU=,tag:lVb2V+75dLakC/L0NRCfpQ==,type:str]
+    REDIS_HOSTNAME: ENC[AES256_GCM,data:5vc6uutFE135jSY4G1O9EodgLiuhpaNLpL8r2FxppqysFCnPvpOYBxc=,iv:1kAV12NwjHtcsteY1U5/TKgM9smqovC9sufM7JR/AGc=,tag:WTZNZV4F2pOM20u/0oXQNQ==,type:str]
+    REDIS_PORT: ENC[AES256_GCM,data:hnkRiQ==,iv:BdHHvlnsU4/+sHlgEsdab2TpboHr6B8/h29VWWGSs4s=,tag:BGNKmgtKqzIm588AeLS1cw==,type:str]
+    OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:IT2gbNt8gWGyUvE7djScaF14bM4itOCDmOjqevsPiGYiEaXK,iv:EUdEwFG4WaWjVCZ4L0t/ajlaP62lnItSmRi8obsfikM=,tag:JJ5VWaMJUe5aLQXAgmozQg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -22,14 +22,14 @@ sops:
         - recipient: age1rr569v9jm7ck70q4wpnspfhdvt4y5m6s604tx0ygs0a65qkt7g4qdszk6k
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDQ0t1VEVXWGRIQzJSVkNG
-            djFSeGd4aW9wcDk5dkpUUDlCZUNuWGw5WDJZCkdzQm5ZUWpzYWMyZ2IrMmtJUkRY
-            cnp3Rk5ZNTRlR1M0R3UyMSs3b3BTVXcKLS0tIGtKWW1EdjVleXZXRVZYVW5RK0ZR
-            bkhyaVpwUUtZckl2RXhMNmsxUW5najgK4fKWKuN6zqJWtNkCHkF1Myj/ajbLqIpK
-            ccJY+Xgq/pxNFrKaSMhWARs0nYZMQOcOIuMLC/3tYXAMRGXIom9waw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCRElLb2MwcWxjVGwxRWlU
+            cXY3Y092WnZHY2xiYUJ3OXkwZ2VxV3lhdVRnCk1xU0RrRmNjY1psUll3QzBCVnV1
+            TjdYZTFUTDVjSTFUVzFlWkd4OXFBOTQKLS0tIDRMSUJsc3ZVUmEvVTdtZmhDYy9C
+            eFhaYkVMMzc3S25zNmdBakRKWFpLeWcKBwk1LYmrC8hI96Cn17yJXcbjAGvHkYVT
+            C4b0siN8EIQHPafdrXRuoCKk+azjYJDno2IVM4R8gH5hDBCekQN4Pg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-19T07:55:07Z"
-    mac: ENC[AES256_GCM,data:Q5eVaEFQcz2hzCeAWT5qo4/xN1ZUgbkHj4bvh9UkibZtnlZ05eBfoJopi/TLTJLJsiCsPU2sjiKzqYe2hAaSp8s0hweMl0K7CQ9Su1fpbbL606fyWbGrzWKTLbd9HOhXMm9O6d6ufQTfE6pKiwOSTuGL0nPHfxtXZc4MY77l3C4=,iv:AnJn2Sho4GRutpk33tHroMg1CtRlstV3uiZjjYP0Yv0=,tag:a0mzDo4HEvwpifPXLX28ww==,type:str]
+    lastmodified: "2026-07-07T01:00:02Z"
+    mac: ENC[AES256_GCM,data:2eheZnIu93++A691G7AGUiCefm3gpNXi27LSEjK2nu/SLL0D/Bt6Khrx5f1Anzj+Y1LI/9iuqvCx69n2DUC1V89vJGRfpfpKx3Tt9+iqLXGLnsh8HEZH9pjBcK8BXVNzRQJ4842aHCaD+tnQZxggBi4dGSnnjy5PNsEI05tzKY8=,iv:A3wWZSHf10xsJ9rN97Ycpq4CEcm9eD+5rmNju15XU10=,tag:o6sDjXu2td3yQfeqf7+kcQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.1
+    version: 3.9.4

--- a/kubernetes/apps/networking/traefik/app/helm-release.yaml
+++ b/kubernetes/apps/networking/traefik/app/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: traefik
-      version: 40.3.0
+      version: 41.0.2
       sourceRef:
         kind: HelmRepository
         name: traefik
@@ -57,46 +57,45 @@ spec:
         external-dns.alpha.kubernetes.io/hostname: "${SECRET_DEV_DOMAIN}"
       labels:
         cilium.io/l2-ip-pool: reserved
-    logs:
-      general:
-        format: json
-        # TEMPORARY DEBUG: bumped from INFO for diagnosing Conduit/Authelia/OpenWebUI
-        # auth flow (issue cogwheel0/conduit#407). Revert to INFO once diagnosed.
-        level: DEBUG
-      access:
-        enabled: true
-        format: json
-        # TEMPORARY DEBUG: capture auth-relevant request and response headers in
-        # access logs so we can see Authelia injecting Remote-Email/Remote-Name
-        # on chat.${SECRET_DEV_DOMAIN} and confirm whether OpenWebUI's auto-signin
-        # via WEBUI_AUTH_TRUSTED_EMAIL_HEADER actually receives them. The default
-        # for headers is "drop"; we opt specific ones in as "keep" / "redact".
-        # Revert this whole `fields:` block once diagnosed.
-        fields:
-          defaultMode: keep
-          headers:
-            defaultMode: drop
-            names:
-              # Authelia forwardAuth response headers (injected onto request to backend)
-              Remote-User: keep
-              Remote-Name: keep
-              Remote-Email: keep
-              Remote-Groups: keep
-              # Request context — useful for correlating WebView page loads
-              User-Agent: keep
-              Referer: keep
-              Host: keep
-              X-Forwarded-For: keep
-              X-Forwarded-Host: keep
-              X-Forwarded-Uri: keep
-              X-Forwarded-Method: keep
-              # Auth state — REDACT so we see presence/absence without leaking values
-              # TEMPORARY: Cookie kept (not redacted) to diagnose what cookie names
-              # the Dart Conduit client is actually sending. Authorization stays
-              # redacted (it's a real JWT). REVERT once diagnosed.
-              Authorization: redact
-              Cookie: keep
-              Set-Cookie: redact
+    log:
+      format: json
+      # TEMPORARY DEBUG: bumped from INFO for diagnosing Conduit/Authelia/OpenWebUI
+      # auth flow (issue cogwheel0/conduit#407). Revert to INFO once diagnosed.
+      level: DEBUG
+    accessLog:
+      enabled: true
+      format: json
+      # TEMPORARY DEBUG: capture auth-relevant request and response headers in
+      # access logs so we can see Authelia injecting Remote-Email/Remote-Name
+      # on chat.${SECRET_DEV_DOMAIN} and confirm whether OpenWebUI's auto-signin
+      # via WEBUI_AUTH_TRUSTED_EMAIL_HEADER actually receives them. The default
+      # for headers is "drop"; we opt specific ones in as "keep" / "redact".
+      # Revert this whole `fields:` block once diagnosed.
+      fields:
+        defaultMode: keep
+        headers:
+          defaultMode: drop
+          names:
+            # Authelia forwardAuth response headers (injected onto request to backend)
+            Remote-User: keep
+            Remote-Name: keep
+            Remote-Email: keep
+            Remote-Groups: keep
+            # Request context — useful for correlating WebView page loads
+            User-Agent: keep
+            Referer: keep
+            Host: keep
+            X-Forwarded-For: keep
+            X-Forwarded-Host: keep
+            X-Forwarded-Uri: keep
+            X-Forwarded-Method: keep
+            # Auth state — REDACT so we see presence/absence without leaking values
+            # TEMPORARY: Cookie kept (not redacted) to diagnose what cookie names
+            # the Dart Conduit client is actually sending. Authorization stays
+            # redacted (it's a real JWT). REVERT once diagnosed.
+            Authorization: redact
+            Cookie: keep
+            Set-Cookie: redact
 
     experimental:
       plugins: 

--- a/kubernetes/apps/storage/paperless/app/config-pvc.yaml
+++ b/kubernetes/apps/storage/paperless/app/config-pvc.yaml
@@ -1,9 +1,17 @@
 ---
+# PV renamed to `paperless-nfs-v1` to force k8s to create a fresh PV object.
+# The prior `paperless-nfs` PV was created with `spec.nfs.path=/volume3/paperless`
+# back when the Synology NAS served the volume there. When the NAS was
+# reorganized and the volume moved to `/volume1/paperless`, only the
+# ${NFS_PAPERLESS} variable in cluster-settings.yaml was updated — but
+# `spec.nfs.path` on an existing PV is immutable, so paperless-0 has been
+# stuck in ContainerCreating since 2026-07-03 with
+# "mount.nfs: access denied by server while mounting 192.168.0.120:/volume3/paperless".
+# See flux worklog 2026-07-06 for detail.
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: paperless-nfs
-  namespace: storage
+  name: paperless-nfs-v1
 spec:
   capacity:
     storage: 1Mi
@@ -19,6 +27,9 @@ spec:
     - nconnect=8
     - hard
     - noatime
+  claimRef:
+    namespace: storage
+    name: paperless-nfs
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -29,6 +40,7 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: paperless-nfs
+  volumeName: paperless-nfs-v1
   resources:
     requests:
       storage: 1Mi


### PR DESCRIPTION
Three orthogonal cleanups from today's incident-response tail:

## 1. Paperless NFS: \`/volume3\` → \`/volume1\`

The Synology NAS moved paperless to \`/volume1/paperless\`. \`${NFS_PAPERLESS}\` in cluster-settings.yaml was updated, but the existing PV had baked-in \`/volume3/paperless\` (immutable field). paperless-0 has been stuck ContainerCreating for 2d21h with \`mount.nfs: access denied\`.

**Fix**: rename PV \`paperless-nfs\` → \`paperless-nfs-v1\` so Flux creates it fresh. PVC name unchanged (referenced by paperless-0's existingClaim). Old PV/PVC deleted out-of-band before this commit to unblock the mount.

## 2. redis-lb cleanup

Both dawarich and Immich had \`redis-lb.databases.svc.cluster.local\` baked into their sops secrets — leftover from the out-of-band ExternalName alias I created during the 2026-07-04 Redis incident.

- \`immich\` secret: \`REDIS_HOSTNAME\` → \`redis-primary.databases.svc.cluster.local\`
- \`dawarich\` secret: \`REDIS_URL\` → \`redis://:PASS@redis-primary.databases.svc.cluster.local:6379\`

After merge, both pods restart and pick up new secrets → \`redis-lb\` is unreferenced → I'll delete the ExternalName Service (not-in-Git, kubectl only).

**Closes #1961** — the dawarich follow-up. We didn't migrate to Sentinel (single-node Redis instead), but the actionable part of #1961 — stop using \`redis-lb\` — is done here.

## 3. Traefik chart 40.3.0 → 41.0.2 + values migration

HelmRelease has been failing since a Renovate PR bumped image to v3.7.6, which chart 40.3.0 rejects. Chart 41.0.2 supports Traefik Proxy up to v3.7.6.

- Chart bump: absorbs [#1888](https://github.com/lenaxia/talos-ops-prod/pull/1888)
- Values schema: \`logs.general\` → \`log\`, \`logs.access\` → \`accessLog\` (v41.0.0 breaking change). Absorbs [#1959](https://github.com/lenaxia/talos-ops-prod/pull/1959).

All internal fields (format, level, header capture) preserved. DEBUG-level auth-header capture for the Conduit/Authelia diagnostic flow keeps working.

**Supersedes and closes #1888 and #1959.**

## Verified
- \`kustomize build\` clean for all three affected apps
- \`kubeconform\` clean
- Both sops files re-encrypted (\`grep -c 'ENC['\` positive, \`^sops:\` block present)
- Live cluster state before merge: paperless-0 unblockable manually until PV recreated by Flux; dawarich + Immich still running via the redis-lb alias; Traefik pods running fine on chart 40.3.0 + image v3.7.4 (last-good state before the failed upgrade attempt).

## Post-merge (I'll do these)
- Watch Flux reconcile paperless, immich, dawarich, traefik
- \`kubectl delete svc -n databases redis-lb\` once immich + dawarich are on new secrets
- Close #1888, #1959, #1961