### PR TITLE
feat(longhorn): add longhorn-2r StorageClass for lower-durability workloads

### DIFF
--- a/kubernetes/apps/storage/longhorn/app/kustomization.yaml
+++ b/kubernetes/apps/storage/longhorn/app/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ingress.yaml
   - servicemonitor.yaml
   - prometheusrules.yaml
+  - storageclass-2r.yaml

--- a/kubernetes/apps/storage/longhorn/app/storageclass-2r.yaml
+++ b/kubernetes/apps/storage/longhorn/app/storageclass-2r.yaml
@@ -1,0 +1,33 @@
+# Alternate Longhorn StorageClass with 2 replicas instead of 3.
+#
+# Rationale: ephemeral / low-durability workloads (LLMSafeSpaces workspace
+# PVCs, scratch caches, dev sandboxes) don't need triple-replication and the
+# storage cost of 3r crowds worker disks into DiskPressure (Longhorn refuses
+# to schedule replicas once free space < 25% of disk max). See 2026-07-07
+# workspace-stuck-in-creating incident.
+#
+# NOT default. Opt-in via `spec.storageClassName: longhorn-2r` on the PVC,
+# or (for LLMSafeSpaces) via chart value `workspace.defaultStorageClass:
+# longhorn-2r`.
+#
+# All other parameters match the chart-managed `longhorn` StorageClass
+# (see helm-release.yaml). Keep in sync if the chart changes defaults.
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-2r
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "2"
+  staleReplicaTimeout: "30"
+  fromBackup: ""
+  fsType: "ext4"
+  dataLocality: "best-effort"
+  unmapMarkSnapChainRemoved: "ignored"
+  disableRevisionCounter: "true"
+  dataEngine: "v1"
+  backupTargetName: "default"


### PR DESCRIPTION
## Summary

Adds a non-default StorageClass `longhorn-2r` mirroring the chart-managed `longhorn` SC but with `numberOfReplicas: 2` instead of 3.

## Why

The 2026-07-07 workspace-stuck-in-creating incident traced to Longhorn refusing to schedule replicas: all 3 worker disks were below the 25% `storage-minimal-available-percentage` threshold. Ephemeral / low-durability workloads (LLMSafeSpaces workspaces, scratch caches) don't need triple-replication and their 3r footprint was consuming ~50% of the scheduled disk space cluster-wide.

## What this doesn't do

- **Not** set as default. Everything continues to use the current `longhorn` (3r) SC unless it explicitly opts in.
- **Not** migrate existing volumes. Existing 6 workspace volumes were already shrunk in-place via `kubectl patch volumes.longhorn.io ... numberOfReplicas=2` before this PR (safer than migration).

## Follow-up

- LLMSafeSpaces chart PR is being prepared to wire `workspace.defaultStorageClass: longhorn-2r` so new workspaces land here by default.

## Test plan

- `kustomize build kubernetes/apps/storage/longhorn/app` renders both the chart-managed SC and this new one.
- `kubeconform` passes (1 resource valid, 0 errors).
- Post-merge: `kubectl get sc longhorn-2r` should show the resource with `numberOfReplicas: "2"`.

## Runtime impact

Zero until a PVC explicitly requests `storageClassName: longhorn-2r`.