### PR TITLE
feat(llmsafespaces): bump to v0.2.2; pin workspace SC to longhorn-2r

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -17,7 +17,7 @@ spec:
         namespace: flux-system
       interval: 15m
       # `reconcileStrategy: Revision` is retained even though the GitRepository
-      # is now pinned to a semver tag (v0.2.1). Rationale: if we ever move a
+      # is now pinned to a semver tag (v0.2.2). Rationale: if we ever move a
       # tag or point at a branch during an emergency rollback, ChartVersion
       # would refuse to re-package (Chart.yaml version wouldn't change). With
       # Revision, source-controller re-packages on every commit SHA change,
@@ -87,7 +87,7 @@ spec:
     # (upstream v0.2.0+) the project cuts real semver releases and CI
     # publishes `<major>.<minor>.<patch>` OCI tags alongside the immutable
     # `ts-<unix>` tags. We pin to the semver — the GitRepository above is
-    # pinned to the matching `tag: v0.2.1`, so the chart-source tree and
+    # pinned to the matching `tag: v0.2.2`, so the chart-source tree and
     # the deployed images roll atomically. To upgrade, bump both the
     # GitRepository ref and every `image.tag` below in the same commit.
     # To verify a semver tag is present on ghcr:
@@ -95,11 +95,11 @@ spec:
     #   curl -sH "Authorization: Bearer $TOKEN" \
     #     -H "Accept: application/vnd.oci.image.index.v1+json" \
     #     -o /dev/null -w "%{http_code}\n" \
-    #     https://ghcr.io/v2/lenaxia/llmsafespaces/api/manifests/0.2.1
+    #     https://ghcr.io/v2/lenaxia/llmsafespaces/api/manifests/0.2.2
     api:
       replicaCount: 2
       image:
-        tag: "0.2.1"
+        tag: "0.2.2"
       config:
         security:
           allowedOrigins:
@@ -110,7 +110,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.2.1"
+        tag: "0.2.2"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -129,7 +129,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.2.1"
+            tag: "0.2.2"
       freeModelsRefresher:
         enabled: false
 
@@ -196,10 +196,10 @@ spec:
       # Pinned to the same semver as api/controller/relay-router/base — the
       # platform rolls atomically because kind/slug wire format, CRD field
       # `workspace.status.userCredsPresent`, and DB migrations must all be
-      # in lockstep. The upstream release-tag build produces `frontend:0.2.1`
+      # in lockstep. The upstream release-tag build produces `frontend:0.2.2`
       # alongside the other four images.
       image:
-        tag: "0.2.1"
+        tag: "0.2.2"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -213,11 +213,26 @@ spec:
     # ── Workspace runtime images ────────────────────────────────────────────
     # The chart seeds a `base` RuntimeEnvironment CR pointing at the base
     # workspace runtime image. Same semver pinning as api/controller/etc —
-    # release-tag builds publish `base:0.2.1` alongside the other four.
+    # release-tag builds publish `base:0.2.2` alongside the other four.
     runtimeEnvironments:
       base:
         image:
-          tag: "0.2.1"
+          tag: "0.2.2"
+
+    # ── Workspace defaults ──────────────────────────────────────────────────
+    # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart
+    # v0.2.2 (LLMSafeSpaces PR #509) exposes this as a Helm-managed value:
+    # when set, the API pins the `workspace.defaultStorageClass` instance
+    # setting via SetHelmOverrides — admins cannot silently override via
+    # the settings UI (returns 409). See the 2026-07-07 workspace-stuck-in-
+    # creating incident: cluster ran all workspace PVCs at 3r, exhausting
+    # Longhorn's 25% MinimalAvailable threshold on every worker disk. The
+    # `longhorn-2r` SC (talos-ops-prod PR #1976) provides a lower-durability
+    # target for ephemeral workspaces — user data is already backed by
+    # opencode's git-based history + external MCP secrets, so a single
+    # replica loss during eviction is recoverable, not catastrophic.
+    workspace:
+      defaultStorageClass: longhorn-2r
 
     # ── Inference relay ─────────────────────────────────────────────────────
     # The chart's DEFAULT inferenceRelayURL is `https://relay.safespaces.dev`

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.2.1
+    tag: v0.2.2
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
## Summary

Consumes [LLMSafeSpaces v0.2.2](https://github.com/lenaxia/LLMSafeSpaces/releases/tag/v0.2.2) (chart [#509](https://github.com/lenaxia/LLMSafeSpaces/pull/509)) and pins new workspace PVCs to the 2-replica `longhorn-2r` StorageClass added in [#1976](https://github.com/lenaxia/talos-ops-prod/pull/1976).

## Changes

- `kubernetes/flux/repositories/git/llmsafespaces.yaml`: GitRepository ref `v0.2.1` → `v0.2.2`.
- `kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml`:
  - All 5 image tags (`api`, `controller`, `frontend`, `base`, `relay-router`) bumped `0.2.1` → `0.2.2`.
  - Adds `workspace.defaultStorageClass: longhorn-2r` under `values:`. Chart v0.2.2 exposes this as a Helm-managed value; when set, the API pins the `workspace.defaultStorageClass` instance setting via `SetHelmOverrides` — admins cannot silently override via the settings UI (returns 409).

## Motivation

2026-07-07 workspace-stuck-in-creating incident. All 6 pre-existing workspace PVCs were running at `numberOfReplicas: 3`, consuming ~50% of scheduled Longhorn disk cluster-wide. All 3 worker disks fell below the 25% MinimalAvailable threshold, so Longhorn refused to schedule new replicas → new chats hung forever in `Init:0/2` with `AttachVolume.Attach failed`.

Immediate ops fix: in-place `kubectl patch volumes.longhorn.io ... numberOfReplicas=2` on all 6 workspace volumes. Cleared DiskPressure on 2/3 nodes; new workspace creation succeeded.

Structural fix (this PR): every new workspace PVC will use `longhorn-2r` from install, so the cluster no longer accumulates 3-replica ephemeral storage. Databases (`postgres`, `valkey`), media, home apps all remain on the default 3r `longhorn` SC — only workspaces (ephemeral, user-recoverable via git-backed opencode history + external MCP secrets) drop to 2r.

## Test plan

- `kustomize build --enable-helm kubernetes/apps/llmsafespaces/llmsafespaces/app` renders cleanly and includes `workspace: defaultStorageClass: longhorn-2r` in the HelmRelease spec.
- `kubeconform` passes (unrelated Traefik Middleware skipped — no CRD schema in the bundle).
- All 5 `<image>:0.2.2` tags will be verifiable on GHCR once the tag-triggered CI run completes (currently in progress at [run 28848273569](https://github.com/lenaxia/LLMSafeSpaces/actions/runs/28848273569)). Frontend already published (HTTP 200 on manifest). Flux will not converge until all 5 exist.
- Post-merge verification:
  - `kubectl get gitrepository llmsafespaces -n flux-system -o jsonpath='{.status.artifact.revision}'` should show the `v0.2.2` commit.
  - `kubectl get pods -n llmsafespaces -l component=api -o jsonpath='{.items[*].spec.containers[*].image}'` should show `:0.2.2`.
  - `kubectl -n llmsafespaces exec deploy/llmsafespaces-api -- curl -s localhost:8080/api/v1/admin/settings/workspace.defaultStorageClass` should show `readOnly: true, value: "longhorn-2r"` (Tier 1 Helm-managed).
  - Create a new workspace: PVC should show `storageClassName: longhorn-2r`, Longhorn volume `spec.numberOfReplicas: 2`.

## Runtime impact

- Existing workspace PVCs: unaffected. The setting only influences new workspaces. (The 6 pre-existing ones were already shrunk in-place via `kubectl patch`.)
- Databases + other apps: unchanged (still 3r on `longhorn`).
- Admin UI: the `workspace.defaultStorageClass` setting will now render disabled with a "Managed by Helm" badge; `PUT` returns 409.