### PR TITLE
fix(runner): force clean workspace between jobs

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/gokore/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/gokore/helmrelease.yaml
@@ -45,3 +45,7 @@ spec:
             env:
               - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
                 value: "false"
+              # Force clean checkout on every job — prevents stale cached files
+              # from persisting on the ReadWriteOnce work volume between runs.
+              - name: ACTIONS_RUNNER_CLEAN_WORKSPACE
+                value: "true"


### PR DESCRIPTION
## Problem

The gokore-runner uses a persistent ReadWriteOnce work volume (openebs-hostpath, 25Gi). Stale files from previous CI runs survive on this volume between jobs. `actions/checkout@v4`'s `clean: true` option does NOT fully remove stale files in Kubernetes container mode.

This causes **phantom gofmt failures**: the gofmt binary on CI reports files as 'not formatted' that are byte-for-byte clean when checked with the exact same Go 1.26.4 gofmt binary locally. The CI's gofmt sees stale cached file content from the persistent volume — content that doesn't exist in any git commit (e.g. it sees `"ITID"` where the file has `"ItemID"`).

## Proof

- Same gofmt binary (SHA256 identical between mise Go 1.26.4 and official go.dev Go 1.26.4)
- Same files (git checkout verified clean: 0 modified files)
- Same Go version (go1.26.4 linux/amd64)
- CI reports 3 files unformatted; local reports 0

The persistent volume is the only variable.

## Fix

Added `ACTIONS_RUNNER_CLEAN_WORKSPACE=true` env var to the runner container. This forces the runner to delete all files in the workspace directory before each job, preventing stale content from accumulating on the persistent volume.

## Impact

Resolves recurring Code Quality workflow failures on goKore PR #113 (and all future PRs).