### PR TITLE
fix(ragnarok): drop hostNetwork from rAthena servers

### DIFF
--- a/kubernetes/apps/ragnarok/rathena/classic/helm-release.yaml
+++ b/kubernetes/apps/ragnarok/rathena/classic/helm-release.yaml
@@ -25,8 +25,6 @@ spec:
         type: deployment
         replicas: 1
         strategy: Recreate
-        pod:
-          hostNetwork: true
         containers:
           server:
             image:
@@ -86,7 +84,15 @@ spec:
     service:
       main:
         enabled: true
+        primary: true
+        controller: main
         type: LoadBalancer
+        # Pin the VIP so removing hostNetwork doesn't reshuffle it.
+        loadBalancerIP: 192.168.5.134
+        # Preserve client source IP for rAthena's IP-ban / login-log features.
+        # Cilium L2 announcements route traffic only to nodes with a Ready
+        # endpoint pod, so `Local` is safe with our single-replica deployment.
+        externalTrafficPolicy: Local
         labels:
           app: rathena
         ports:
@@ -99,4 +105,3 @@ spec:
           map:
             port: 5121
             enabled: true
-        primary: true

--- a/kubernetes/apps/ragnarok/rathena/classic/helm-release.yaml
+++ b/kubernetes/apps/ragnarok/rathena/classic/helm-release.yaml
@@ -68,15 +68,16 @@ spec:
               - name: ADD_SUBNET_MAP1
                 value: "255.255.255.255:10.96.255.255"
               - name: SET_CHAR_PUBLIC_IP
-                value: "192.168.5.134"
+                value: ${SVC_RATHENA_CLASSIC_ADDR}
               - name: SET_MAP_PUBLIC_IP
-                value: "192.168.5.134"
+                value: ${SVC_RATHENA_CLASSIC_ADDR}
               - name: SET_MAP_TO_CHAR_IP
-                value: "192.168.5.134"
-              # Internal char->login handshake stays on loopback. hostNetwork means
-              # login-server and char-server share the pod's network namespace, so
-              # 127.0.0.1 is always reachable and immune to Cilium/multus/interface
-              # autodetect changes that were picking a link-local 169.254.x/32 route.
+                value: ${SVC_RATHENA_CLASSIC_ADDR}
+              # Internal char->login handshake stays on loopback. Both processes
+              # run in the same pod (same netns), so 127.0.0.1 is always
+              # reachable and immune to interface-autodetect regressions that
+              # previously grabbed a link-local 169.254.x/32 host route when
+              # hostNetwork: true was in use.
               - name: SET_CHAR_TO_LOGIN_IP
                 value: "127.0.0.1"
               - name: MYSQL_ACCOUNTSANDCHARS
@@ -88,7 +89,7 @@ spec:
         controller: main
         type: LoadBalancer
         # Pin the VIP so removing hostNetwork doesn't reshuffle it.
-        loadBalancerIP: 192.168.5.134
+        loadBalancerIP: ${SVC_RATHENA_CLASSIC_ADDR}
         # Preserve client source IP for rAthena's IP-ban / login-log features.
         # Cilium L2 announcements route traffic only to nodes with a Ready
         # endpoint pod, so `Local` is safe with our single-replica deployment.

--- a/kubernetes/apps/ragnarok/rathena/renewal/helm-release.yaml
+++ b/kubernetes/apps/ragnarok/rathena/renewal/helm-release.yaml
@@ -67,15 +67,16 @@ spec:
               - name: ADD_SUBNET_MAP1
                 value: "255.255.255.255:10.96.255.255"
               - name: SET_CHAR_PUBLIC_IP
-                value: "192.168.5.145"
+                value: ${SVC_RATHENA_RENEWAL_ADDR}
               - name: SET_MAP_PUBLIC_IP
-                value: "192.168.5.145"
+                value: ${SVC_RATHENA_RENEWAL_ADDR}
               - name: SET_MAP_TO_CHAR_IP
-                value: "192.168.5.145"
-              # Internal char->login handshake stays on loopback. hostNetwork means
-              # login-server and char-server share the pod's network namespace, so
-              # 127.0.0.1 is always reachable and immune to Cilium/multus/interface
-              # autodetect changes that were picking a link-local 169.254.x/32 route.
+                value: ${SVC_RATHENA_RENEWAL_ADDR}
+              # Internal char->login handshake stays on loopback. Both processes
+              # run in the same pod (same netns), so 127.0.0.1 is always
+              # reachable and immune to interface-autodetect regressions that
+              # previously grabbed a link-local 169.254.x/32 host route when
+              # hostNetwork: true was in use.
               - name: SET_CHAR_TO_LOGIN_IP
                 value: "127.0.0.1"
               - name: MYSQL_ACCOUNTSANDCHARS
@@ -89,7 +90,7 @@ spec:
         controller: main
         type: LoadBalancer
         # Pin the VIP so removing hostNetwork doesn't reshuffle it.
-        loadBalancerIP: 192.168.5.145
+        loadBalancerIP: ${SVC_RATHENA_RENEWAL_ADDR}
         # Preserve client source IP for rAthena's IP-ban / login-log features.
         # Cilium L2 announcements route traffic only to nodes with a Ready
         # endpoint pod, so `Local` is safe with our single-replica deployment.

--- a/kubernetes/apps/ragnarok/rathena/renewal/helm-release.yaml
+++ b/kubernetes/apps/ragnarok/rathena/renewal/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
         type: deployment
         replicas: 1
         strategy: Recreate
-        pod:
-          hostNetwork: true
         containers:
           server:
             image:
@@ -87,7 +85,15 @@ spec:
     service:
       main:
         enabled: true
+        primary: true
+        controller: main
         type: LoadBalancer
+        # Pin the VIP so removing hostNetwork doesn't reshuffle it.
+        loadBalancerIP: 192.168.5.145
+        # Preserve client source IP for rAthena's IP-ban / login-log features.
+        # Cilium L2 announcements route traffic only to nodes with a Ready
+        # endpoint pod, so `Local` is safe with our single-replica deployment.
+        externalTrafficPolicy: Local
         labels:
           app: rathena
         ports:
@@ -100,7 +106,6 @@ spec:
           map:
             port: 5121
             enabled: true
-        primary: true
     persistence:
       entrypoint-sh:
         enabled: true


### PR DESCRIPTION
## Summary

- Removes `pod.hostNetwork: true` from `rathena-renewal` and `rathena-classic` HRs
- Explicitly pins `loadBalancerIP` (`192.168.5.145` / `192.168.5.134`) so removing hostNetwork doesn't drop the VIPs
- Sets `externalTrafficPolicy: Local` so rAthena's login-log / IP-ban features see the real client IP

## Why

Two rAthena pods scheduled to the same node with `hostNetwork: true` both tried to bind `0.0.0.0:{6900,6121,5121}`. Because rAthena uses `SO_REUSEADDR`, both binds *succeed silently* and the kernel round-robins accepted connections between the two login-servers.

Symptoms:
- Client authenticates as `Almarc` against renewal's VIP (`192.168.5.145`)
- kernel actually delivers the packet to `classic`'s login-server (bound to the same host wildcard port)
- classic returns `account_id=2000001` (Almarc's classic account)
- client dials char-server on `192.168.5.134`... kernel delivers to renewal's char-server
- renewal char-server: "authentication of the account 2000001 REFUSED" - Almarc is `2000601` on renewal, not `2000001`

The parent commit (`dfefcf78`) fixed one prerequisite: char-server was picking a `169.254.x/32` link-local host route as its login-server address after the Jul 3 Cilium/multus prep changes. `SET_CHAR_TO_LOGIN_IP=127.0.0.1` pins the intra-pod handshake to loopback and is unaffected by this PR (loopback works the same regardless of netns).

## Verification

- ✅ Manifests parse (`python3 yaml.safe_load`)
- ✅ Both pods currently coexist on `worker-01` in prod; after this change each gets its own netns and can no longer collide on host ports
- ⏳ Post-merge Flux reconcile will roll both deployments; client login should succeed cleanly against both `.145` (renewal) and `.134` (classic) simultaneously

## Rollout plan

- Merge → Flux reconciles renewal + classic HRs → deployments recreate with new podSpec + updated Service
- `strategy: Recreate` (already in place) drops the old pod before starting the new one, releasing the RWO configMap mount cleanly
- LB VIPs stay stable because of the new explicit `loadBalancerIP` pin