### PR TITLE
fix(gokore-ci): grant replicasets read for helm --wait

### DIFF
--- a/kubernetes/apps/gokore-ci/rbac.yaml
+++ b/kubernetes/apps/gokore-ci/rbac.yaml
@@ -33,6 +33,12 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # ReplicaSets — read-only. Helm --wait lists ReplicaSets (owned by the
+  # Deployments above) to track rollout status. The Deployment controller
+  # creates/owns them; the runner only needs to read them.
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
   # Events — for debugging scheduling failures:
   - apiGroups: [""]
     resources: ["events"]


### PR DESCRIPTION
## Summary

One-line RBAC fix: add `replicasets.apps` (get/list/watch) to the `gokore-ci-runner` Role.

## Why

The e2e-live workflow (goKore #145, merged) failed on `main` with:

```
replicasets.apps is forbidden: User "system:serviceaccount:actions-runner-system:gokore-ci-runner"
cannot list resource "replicasets" in API group "apps" in the namespace "gokore-ci"
```

`helm upgrade --install --wait` lists ReplicaSets (owned by the Deployments it deploys) to track rollout status. The Phase 0 PR (#1979) granted `deployments.apps` but missed `replicasets.apps`.

## What

- Added a read-only rule for `replicasets.apps` (get/list/watch). The Deployment controller creates/owns ReplicaSets; the runner only reads them — no create/update/delete needed.

## Validation

```
✓ kubeconform -strict -ignore-missing-schemas
```

## Verification

After this merges, re-triggering `e2e-live.yml` on goKore `main` should pass the `helm install --wait` step (the first real end-to-end validation of the chart + RBAC + workflow).