### PR TITLE
fix(runner): automount SA token so helm/kubectl can auth

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/gokore/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/gokore/helmrelease.yaml
@@ -28,6 +28,11 @@ spec:
       namespace: actions-runner-system
     template:
       spec:
+        # Mount the runner pod's SA token so helm/kubectl can auth to the API.
+        # ARC kubernetes-mode pods don't automount the token by default (they're
+        # designed for container jobs, not API access). The e2e-live workflow
+        # needs API access to deploy Helm releases into gokore-ci.
+        automountServiceAccountToken: true
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Follow-up to hotfix #1982 — runner pods can't auth to k8s API

After #1982 fixed the runner scaling, the e2e-live workflow fails at `helm install` with:

```
Error: Kubernetes cluster unreachable: the server has asked for the client to provide credentials
```

## Root cause

ARC `containerMode: kubernetes` pods **don't automount the SA token** by default. They're designed to run container jobs via runner-container-hooks, not talk to the k8s API directly. When the e2e-live workflow runs `helm`/`kubectl` inside the runner pod, there are no credentials available.

## Fix

One line: `automountServiceAccountToken: true` on the runner pod template. The pod runs as ARC's auto-created SA (`gokore-runner-gha-rs-kube-mode`), which the `gokore-ci` RoleBinding (from #1982) grants the necessary permissions. The mounted token lets `helm`/`kubectl` auth as that SA.

## After merge

Flux reconciles → ARC recycles runner pods with the token mounted → e2e-live workflow can deploy Helm releases.
