### PR TITLE
feat(utilities): add Wealthfolio app deployment via app-template

### DIFF
--- a/kubernetes/apps/utilities/kustomization.yaml
+++ b/kubernetes/apps/utilities/kustomization.yaml
@@ -18,4 +18,5 @@ resources:
   - ./brother-ql-web/ks.yaml
   - ./forgejo/ks.yaml
   - ./it-tools/ks.yaml
+  - ./wealthfolio/ks.yaml
     #- ./k8sgpt/ks.yaml

--- a/kubernetes/apps/utilities/wealthfolio/app/helm-release.yaml
+++ b/kubernetes/apps/utilities/wealthfolio/app/helm-release.yaml
@@ -1,0 +1,111 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/helm.toolkit.fluxcd.io/helmrelease_v2beta1.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app wealthfolio
+  namespace: &namespace utilities
+spec:
+  releaseName: *app
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+      interval: 10m
+  interval: 6m
+  install:
+    createNamespace: true
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  values:
+    defaultPodOptions:
+      nodeSelector:
+        node-role.kubernetes.io/worker: 'true'
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+
+    controllers:
+      main:
+        type: deployment
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: 'true'
+        containers:
+          main:
+            image:
+              repository: wealthfolio/wealthfolio
+              tag: 3.6.1
+            env:
+              TZ: ${TIMEZONE}
+              WF_LISTEN_ADDR: 0.0.0.0:8088
+              WF_DB_PATH: /data/wealthfolio.db
+              WF_CORS_ALLOW_ORIGINS: https://wealthfolio.${SECRET_DEV_DOMAIN}
+              WF_STATIC_DIR: dist
+              WF_AUTH_REQUIRED: "false"
+              WF_COOKIE_SECURE: auto
+              # TODO: Move WF_SECRET_KEY to a SOPS-encrypted secret.sops.yaml
+              # Generate: openssl rand -base64 32
+              # Then add secret.sops.yaml to app/kustomization.yaml and
+              # uncomment the envFrom block below:
+              WF_SECRET_KEY: "CHANGE-ME-REPLACE-WITH-REAL-KEY"
+            # envFrom:
+            #   - secretRef:
+            #       name: *app
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+
+    service:
+      main:
+        primary: true
+        ports:
+          http:
+            port: 8088
+
+    ingress:
+      main:
+        enabled: true
+        className: traefik
+        annotations:
+          hajimari.io/enable: 'true'
+          hajimari.io/icon: cash-multiple
+          hajimari.io/group: Utilities
+          cert-manager.io/cluster-issuer: letsencrypt-production
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+          traefik.ingress.kubernetes.io/router.middlewares:
+            networking-chain-authelia@kubernetescrd
+        hosts:
+          - host: &uri wealthfolio.${SECRET_DEV_DOMAIN}
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  identifier: main
+                  port: http
+        tls:
+          - hosts:
+              - *uri
+            secretName: *uri
+
+    persistence:
+      data:
+        enabled: true
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        storageClass: longhorn
+        retain: true
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/utilities/wealthfolio/app/helm-release.yaml
+++ b/kubernetes/apps/utilities/wealthfolio/app/helm-release.yaml
@@ -52,14 +52,9 @@ spec:
               WF_STATIC_DIR: dist
               WF_AUTH_REQUIRED: "false"
               WF_COOKIE_SECURE: auto
-              # TODO: Move WF_SECRET_KEY to a SOPS-encrypted secret.sops.yaml
-              # Generate: openssl rand -base64 32
-              # Then add secret.sops.yaml to app/kustomization.yaml and
-              # uncomment the envFrom block below:
-              WF_SECRET_KEY: "CHANGE-ME-REPLACE-WITH-REAL-KEY"
-            # envFrom:
-            #   - secretRef:
-            #       name: *app
+            envFrom:
+              - secretRef:
+                  name: *app
             resources:
               requests:
                 cpu: 100m

--- a/kubernetes/apps/utilities/wealthfolio/app/kustomization.yaml
+++ b/kubernetes/apps/utilities/wealthfolio/app/kustomization.yaml
@@ -6,3 +6,4 @@ commonLabels:
   app.kubernetes.io/instance: *app
 resources:
   - helm-release.yaml
+  - secret.sops.yaml

--- a/kubernetes/apps/utilities/wealthfolio/app/kustomization.yaml
+++ b/kubernetes/apps/utilities/wealthfolio/app/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: utilities
+commonLabels:
+  app.kubernetes.io/name: &app wealthfolio
+  app.kubernetes.io/instance: *app
+resources:
+  - helm-release.yaml

--- a/kubernetes/apps/utilities/wealthfolio/app/secret.sops.yaml
+++ b/kubernetes/apps/utilities/wealthfolio/app/secret.sops.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: wealthfolio
+  namespace: utilities
+stringData:
+  # Generate a 32-byte key: openssl rand -base64 32
+  # Replace PLACEHOLDER with the actual key, then run:
+  #   sops --encrypt --in-place kubernetes/apps/utilities/wealthfolio/app/secret.sops.yaml
+  WF_SECRET_KEY: PLACEHOLDER

--- a/kubernetes/apps/utilities/wealthfolio/ks.yaml
+++ b/kubernetes/apps/utilities/wealthfolio/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomization_v1beta2.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-utilities-wealthfolio
+  namespace: flux-system
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  dependsOn:
+    - name: cluster-storage-longhorn
+  path: ./kubernetes/apps/utilities/wealthfolio/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+      kind: HelmRelease
+      name: wealthfolio
+      namespace: utilities
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m


### PR DESCRIPTION
Deploy **Wealthfolio v3.6.1** — a private, local-first personal finance tracker (investments, net worth, spending).

**Chart:** bjw-s app-template v5.0.1
**Image:** `wealthfolio/wealthfolio:3.6.1`
**Persistence:** 1Gi Longhorn PVC at `/data` (SQLite DB)
**Ingress:** Authelia-protected at `wealthfolio.${SECRET_DEV_DOMAIN}`
**Auth:** `WF_AUTH_REQUIRED=false` (Authelia handles auth layer)
**Secret:** skeleton `secret.sops.yaml` included

### Pre-merge checklist
- [ ] Generate `WF_SECRET_KEY`: `openssl rand -base64 32`
- [ ] Edit the secret file: `sops kubernetes/apps/utilities/wealthfolio/app/secret.sops.yaml`
- [ ] Verify encryption: `grep '^sops:' kubernetes/apps/utilities/wealthfolio/app/secret.sops.yaml`
- [ ] Amend/push the encrypted secret before merging