### PR TITLE
feat(wealthfolio): configure Authelia OIDC SSO

### DIFF
--- a/kubernetes/apps/networking/authelia/app/helm-release.yaml
+++ b/kubernetes/apps/networking/authelia/app/helm-release.yaml
@@ -871,6 +871,20 @@ spec:
             id_token_signed_response_alg: 'RS256'
             userinfo_signed_response_alg: 'RS256'
             token_endpoint_auth_method: 'client_secret_post'
+          - client_id: wealthfolio
+            client_name: Wealthfolio
+            client_secret: "${SECRET_WEALTHFOLIO_OAUTH_CLIENT_SECRET_HASHED}"
+            public: false
+            authorization_policy: one_factor
+            consent_mode: implicit
+            pre_configured_consent_duration: 1y
+            scopes: ["openid", "profile", "email"]
+            redirect_uris: ["https://wealthfolio.${SECRET_DEV_DOMAIN}/api/v1/auth/oidc/callback"]
+            response_types:
+              - 'code'
+            grant_types:
+              - 'authorization_code'
+            token_endpoint_auth_method: 'client_secret_basic'
             # -
                ## The ID is the OpenID Connect ClientID which is used to link an application to a configuration.
               # id: myapp

--- a/kubernetes/apps/utilities/wealthfolio/app/helm-release.yaml
+++ b/kubernetes/apps/utilities/wealthfolio/app/helm-release.yaml
@@ -50,8 +50,12 @@ spec:
               WF_DB_PATH: /data/wealthfolio.db
               WF_CORS_ALLOW_ORIGINS: https://wealthfolio.${SECRET_DEV_DOMAIN}
               WF_STATIC_DIR: dist
-              WF_AUTH_REQUIRED: "false"
               WF_COOKIE_SECURE: auto
+              WF_OIDC_ISSUER_URL: https://auth.${SECRET_DEV_DOMAIN}
+              WF_OIDC_CLIENT_ID: wealthfolio
+              WF_OIDC_CLIENT_SECRET: ${SECRET_WEALTHFOLIO_OAUTH_CLIENT_SECRET}
+              WF_OIDC_REDIRECT_URL: https://wealthfolio.${SECRET_DEV_DOMAIN}/api/v1/auth/oidc/callback
+              WF_OIDC_ALLOW_ANY: "true"
             envFrom:
               - secretRef:
                   name: *app


### PR DESCRIPTION
Adds Wealthfolio as an Authelia OIDC client so the secrets API (and other auth-gated endpoints) work with seamless SSO — no double login.

### Authelia (`networking/authelia/app/helm-release.yaml`)
- New OIDC client: `wealthfolio`
- Uses `SECRET_WEALTHFOLIO_OAUTH_CLIENT_SECRET_HASHED` from cluster-secrets
- Redirect URI: `https://wealthfolio.${SECRET_DEV_DOMAIN}/api/v1/auth/oidc/callback`

### Wealthfolio (`utilities/wealthfolio/app/helm-release.yaml`)
- Added `WF_OIDC_ISSUER_URL`, `WF_OIDC_CLIENT_ID`, `WF_OIDC_CLIENT_SECRET`, `WF_OIDC_REDIRECT_URL`
- Set `WF_OIDC_ALLOW_ANY=true` (single-user setup)
- Removed `WF_AUTH_REQUIRED=false` (no longer needed — OIDC provides auth)

### Pre-merge checklist
- [ ] Verify `SECRET_WEALTHFOLIO_OAUTH_CLIENT_SECRET` and `SECRET_WEALTHFOLIO_OAUTH_CLIENT_SECRET_HASHED` exist in `kubernetes/flux/vars/secret.sops.yaml`