### PR TITLE
fix(esphome): correct MP3 announce format key (was breaking compile)

### DIFF
--- a/kubernetes/apps/home/esphome/app/config/common/respeaker-satellite-base.yaml
+++ b/kubernetes/apps/home/esphome/app/config/common/respeaker-satellite-base.yaml
@@ -1245,7 +1245,10 @@ media_player:
     id: external_media_player
     name: Media Player
     announcement_pipeline:
-      format: FLAC     # FLAC is the least processor intensive codec
+      format: MP3      # Advertises MP3 (purpose=announcement) to HA. HA's TTS layer
+                       # reads this and requests MP3 from Piper instead of FLAC.
+                       # Sonos's AudioClip API (used by announce: true play_media)
+                       # silently rejects FLAC; MP3 works reliably.
       num_channels: 1  # Stereo audio is unnecessary for announcements
       sample_rate: 48000
       speaker: announcement_resampling_speaker
@@ -1260,22 +1263,6 @@ media_player:
       sources:
         - http_media_source
         - sendspin_media_source
-    # Advertise MP3 as the preferred announcement format so HA's TTS layer
-    # (which reads this list and picks the first matching purpose=announcement
-    # entry) requests MP3 from Piper instead of FLAC. Sonos's AudioClip API
-    # (used by media_player.play_media with announce: true) accepts MP3 reliably
-    # but silently rejects FLAC. MP3 first = HA sends MP3 = Sonos ducks + plays.
-    supported_formats:
-      - format: mp3
-        sample_rate: 22050
-        num_channels: 1
-        sample_bytes: 2
-        purpose: announcement
-      - format: flac
-        sample_rate: 48000
-        num_channels: 1
-        sample_bytes: 2
-        purpose: announcement
     volume_increment: 0.05
     volume_min: 0.4
     volume_max: 0.85


### PR DESCRIPTION
## Summary

Hotfix for #1987 — the previous PR used `supported_formats:` as a top-level key on `media_player.speaker_source`, which is not a valid option for that platform. ESPHome refused to compile with:

```
[supported_formats] is an invalid option for [media_player.speaker_source]. Please check the indentation.
```

## Root cause

I assumed `supported_formats` was the right key based on how HA reads the device-advertised formats (`homeassistant/components/esphome/assist_satellite.py:_update_tts_format()`). That part is correct — HA does read a list of `MediaPlayerSupportedFormat` and picks the first one with `purpose=ANNOUNCEMENT`.

What I missed is that on the `speaker_source` platform (a FormatBCE custom component), the format is set **inside each pipeline block**, and the platform auto-attaches the `ANNOUNCEMENT` or `default` purpose based on which pipeline it lives in.

The actual schema (`formatBCE/esphome@respeaker_microphone` `esphome/components/speaker_source/media_player.py`):

```python
PIPELINE_SCHEMA = cv.Schema({
    cv.Required(CONF_SPEAKER): cv.use_id(speaker.Speaker),
    cv.Required(CONF_SOURCES): cv.ensure_list(cv.use_id(media_source.MediaSource)),
    cv.Optional(CONF_FORMAT, default=\"FLAC\"): cv.enum(audio.AUDIO_FILE_TYPE_ENUM),
    cv.Optional(CONF_SAMPLE_RATE): cv.int_range(min=1),
    cv.Optional(CONF_NUM_CHANNELS): cv.int_range(1, 2),
})
```

`format: MP3` under `announcement_pipeline:` produces a `MediaPlayerSupportedFormat{format=\"mp3\", purpose=ANNOUNCEMENT}` advertised to HA. HA then requests MP3 from Piper. Sonos accepts MP3, rejects FLAC.

## Fix

One-line change: `format: FLAC` → `format: MP3` under `announcement_pipeline:`. Removed the invalid `supported_formats:` block entirely.

## Verification

- Schema cross-checked against `formatBCE/esphome@respeaker_microphone` source
- Pattern matches `esphome/home-assistant-voice-pe` reference config (lines 1644-1662 of `home-assistant-voice.yaml`)
- No fork modification required — this was always supported, just under a different key

## Pre-merge checklist

- [ ] ESPHome compiles a device YAML referencing this base
- [ ] After flash, `esphome.tts_uri` event URL ends in `.mp3` (not `.flac`)
- [ ] Sonos plays TTS with `announce: true`

Follows up #1987.