### PR TITLE
feat(esphome): publish mic RMS level for multi-satellite routing

### DIFF
--- a/kubernetes/apps/home/esphome/app/config/common/respeaker-satellite-base.yaml
+++ b/kubernetes/apps/home/esphome/app/config/common/respeaker-satellite-base.yaml
@@ -711,6 +711,25 @@ sensor:
     device_class: duration
     unit_of_measurement: s
     icon: "mdi:timer"
+  # Microphone RMS level (passive) - taps the same mic stream that micro_wake_word
+  # uses, so it only updates while wake word detection is active. Used by HA-side
+  # amplitude-based routing when multiple satellites hear the same wake word.
+  # 0 dBFS = loudest mic input, more negative = quieter. Kitchen satellite might
+  # read -25 dBFS for nearby speech, bedroom satellite reads -55 for the same
+  # source across the house. Highest value wins the routing decision.
+  - platform: sound_level
+    passive: true
+    measurement_duration: 250ms
+    microphone:
+      microphone: i2s_mics
+      channels: [0]
+    rms:
+      name: "Mic RMS Level"
+      id: mic_rms_level
+      filters:
+        - sliding_average_moving_window:
+            window_size: 4
+            send_every: 1
 
 text_sensor:
   - platform: template

--- a/kubernetes/apps/home/home-assistant/VOICE-SATELLITE.md
+++ b/kubernetes/apps/home/home-assistant/VOICE-SATELLITE.md
@@ -195,6 +195,46 @@ curl -o kubernetes/apps/home/esphome/app/config/common/respeaker-satellite-base.
 Check FormatBCE's changelog before updating — they may break things.
 Test on a non-production satellite first if you have one.
 
+## Multi-satellite routing
+
+When two or more satellites hear the same wake word, HA's built-in
+`WAKE_WORD_COOLDOWN = 2s` (in `homeassistant/components/assist_pipeline/const.py`)
+blocks the second pipeline from starting. The first-to-fire wins. This handles
+the common case but has known gaps:
+
+- Beyond 2 seconds, both satellites can fire independently.
+- Adjacent-room sensitivity settings may cause wrong-room wins.
+- No spatial preference — purely first-across-the-line.
+
+### Amplitude-based routing (DIY)
+
+Each satellite publishes a `sensor.<device>_mic_rms_level` entity via
+ESPHome's built-in `sound_level` sensor (passive mode, taps the same mic
+stream `micro_wake_word` uses). Values are in relative dBFS where 0 is
+the loudest the mic can measure, more negative is quieter.
+
+For the same utterance, the closest satellite typically reads 20-40 dB
+louder than one in an adjacent room. Component tolerance, XMOS AGC, and
+room acoustics add ~5 dB of noise — but the signal vastly exceeds the
+noise in most home layouts.
+
+A HA automation listens for `esphome.wake_word_detected` events, collects
+RMS from all satellites over a short window (~250ms), and routes TTS to
+the Sonos in the room of the loudest satellite. Building this is left to
+the user — see https://www.home-assistant.io/voice_control/ for current
+pipeline behavior.
+
+### Calibration
+
+Single-tone-at-known-distance calibration corrects for per-device gain
+offset (mic tolerance, XMOS AGC settings). Play a 1kHz tone from a
+speaker at 1m, record RMS per satellite, save the offsets as a HA
+input_number per device. Subtract the offset in the routing automation.
+
+Calibration does NOT correct for room acoustics, mic orientation, or
+obstructions. Those add ±5-10 dB of variability. In practice this
+matters only for adjacent-room edge cases.
+
 ## References
 
 - FormatBCE repo: https://github.com/formatBCE/Respeaker-Lite-ESPHome-integration


### PR DESCRIPTION
## Summary

Adds ESPHome's built-in `sound_level` sensor in passive mode to the FormatBCE base YAML. This publishes `sensor.<device>_mic_rms_level` in relative dBFS, enabling amplitude-based routing when multiple satellites hear the same wake word.

## Why

HA's Assist pipeline only has a 2-second cross-device cooldown (`WAKE_WORD_COOLDOWN` in `assist_pipeline/const.py`) for handling multi-satellite wake word conflicts. It works for the common case but:
- Loses race conditions beyond 2 seconds
- Has no spatial preference — first-to-fire wins
- Can't pick the closest satellite when multiple hear the same utterance

Amazon Echo solves this with "Echo Spatial Perception" (ESP) — pure amplitude-based routing. This PR enables the same approach for ESPHome satellites by exposing mic RMS to HA.

## What

Two changes:

**1. `kubernetes/apps/home/esphome/app/config/common/respeaker-satellite-base.yaml`** — add a `sound_level` sensor block:

```yaml
sensor:
  - platform: sound_level
    passive: true
    measurement_duration: 250ms
    microphone:
      microphone: i2s_mics
      channels: [0]
    rms:
      name: "Mic RMS Level"
      id: mic_rms_level
      filters:
        - sliding_average_moving_window:
            window_size: 4
            send_every: 1
```

Passive mode means it taps the same mic stream `micro_wake_word` is already capturing — no extra audio capture overhead, only publishes while wake word detection is active.

**2. `kubernetes/apps/home/home-assistant/VOICE-SATELLITE.md`** — added a "Multi-satellite routing" section documenting:
- The 2-second cooldown limitation
- The amplitude-based routing approach
- Single-tone-at-known-distance calibration procedure
- Honest caveats (room acoustics, mic orientation are NOT corrected by calibration)

## Considered alternatives

| Option | Verdict |
|---|---|
| Custom ESPHome C++ component | Rejected — official `sound_level` exists since ESPHome 2025.6.0, maintained by core audio maintainer (kahrendt) |
| `stas-sl/esphome-sound-level-meter` | Rejected — author themselves recommends the official sensor for basic amplitude; only useful for calibrated absolute dB SPL or A/C-weighting |
| Fork FormatBCE to add a mic level hook | Rejected — not needed, `sound_level` uses the public `microphone` source API |

## What this does NOT do

- **HA-side routing automation is left to the user.** Three reasons: requires per-household calibration values; HA's `assist_pipeline` API doesn't expose a clean "cancel other pipeline runs" hook from an automation; current 2-second cooldown handles most cases.
- **No true spatial/distance measurement.** The 2-mic ReSpeaker Lite can't measure distance — only angle via TDOA, and FormatBCE doesn't expose DOA. Amplitude is a distance proxy, not a true measurement.
- **No automatic calibration.** Documented in the README but requires a human with a tone generator and tape measure.

## Pre-merge checklist

- [ ] ESPHome compiles with this addition (sound_level is built-in, should be no-op but verify)
- [ ] After flash, `sensor.respeaker_kitchen_mic_rms_level` entity exists and updates ~4x/sec while wake word is listening
- [ ] Value is in expected range (silent room: -90 to -70 dBFS, normal speech at 1m: -40 to -20 dBFS)

## References

- ESPHome sound_level docs: https://esphome.io/components/sensor/sound_level.html
- Initial implementation PR: https://github.com/esphome/esphome/pull/8737
- Ring-buffer optimization PR (May 2026): https://github.com/esphome/esphome/pull/16436
