### PR TITLE
feat(kicad): add KiCad 9 streaming workstation (Selkies + Sunshine + MCP)

### DIFF
--- a/.taskfiles/workstation/Taskfile.yaml
+++ b/.taskfiles/workstation/Taskfile.yaml
@@ -71,9 +71,19 @@ tasks:
               echo "installing $name from $url"
               case "$url" in
                   *.tar.gz|*.tgz)
-                      curl -fsSL "$url" | tar xzf - -O > "$name" 2>/dev/null \
-                          || curl -fsSL "$url" | tar xzf - --strip-components=1 -C . 2>/dev/null \
-                          || curl -fsSL -o "${name}.tar.gz" "$url" && tar xzf "${name}.tar.gz" && rm -f "${name}.tar.gz"
+                      local tmpdir; tmpdir=$(mktemp -d)
+                      curl -fsSL "$url" | tar xzf - -C "$tmpdir"
+                      # Find the named binary in the extracted tree and move it.
+                      local found
+                      found=$(find "$tmpdir" -type f -name "$name" -perm -u+x | head -n1)
+                      [ -z "$found" ] && found=$(find "$tmpdir" -type f -name "$name" | head -n1)
+                      if [ -z "$found" ]; then
+                          echo "binary '$name' not found in $url" >&2
+                          rm -rf "$tmpdir"
+                          return 1
+                      fi
+                      mv "$found" "./$name"
+                      rm -rf "$tmpdir"
                       ;;
                   *)
                       curl -fsSL -o "$name" "$url"

--- a/.taskfiles/workstation/Taskfile.yaml
+++ b/.taskfiles/workstation/Taskfile.yaml
@@ -41,18 +41,58 @@ tasks:
     dir: '{{.ROOT_DIR}}/.bin'
     platforms: ['linux/amd64', 'linux/arm64']
     cmds:
-      - for:
-          - budimanjojo/talhelper?as=talhelper
-          - cloudflare/cloudflared?as=cloudflared
-          - FiloSottile/age?as=age
-          - fluxcd/flux2?as=flux
-          - helmfile/helmfile?as=helmfile
-          - jqlang/jq?as=jq
-          - kubernetes-sigs/kustomize?as=kustomize
-          - mikefarah/yq?as=yq
-          - siderolabs/talos?as=talosctl
-          - yannh/kubeconform?as=kubeconform
-        cmd: curl -fsSL "https://i.jpillora.com/{{.ITEM}}&type=script" | bash
+      # Install CLI tools directly from GitHub releases. Previously this used
+      # the i.jpillora.com installer proxy, which is a third-party service that
+      # has become unreliable (returning 500s). Going direct to the GitHub API
+      # removes a runtime dependency and is the same source the proxy used.
+      # Each `gh_release_install` call fetches the latest release from
+      # api.github.com and picks the asset whose name matches the local arch.
+      - cmd: |
+          set -euo pipefail
+          ARCH=$(uname -m)
+          case "$ARCH" in
+              x86_64)         ARCH='amd64' ;;
+              aarch64|arm64)  ARCH='arm64' ;;
+              *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
+          esac
+          gh_release_install() {
+              local repo="$1" name="$2" asset_re="$3"
+              local release
+              release=$(curl -fsSL "https://api.github.com/repos/${repo}/releases/latest")
+              local url
+              url=$(printf '%s' "$release" \
+                  | jq -r --arg arch "$ARCH" --arg re "$asset_re" \
+                      '.assets[] | select(.name|test($re)) | select(.name|test($arch;"i")) | .browser_download_url' \
+                  | head -n1)
+              if [ -z "$url" ]; then
+                  echo "no asset matched repo=$repo arch=$ARCH pattern=$asset_re" >&2
+                  return 1
+              fi
+              echo "installing $name from $url"
+              case "$url" in
+                  *.tar.gz|*.tgz)
+                      curl -fsSL "$url" | tar xzf - -O > "$name" 2>/dev/null \
+                          || curl -fsSL "$url" | tar xzf - --strip-components=1 -C . 2>/dev/null \
+                          || curl -fsSL -o "${name}.tar.gz" "$url" && tar xzf "${name}.tar.gz" && rm -f "${name}.tar.gz"
+                      ;;
+                  *)
+                      curl -fsSL -o "$name" "$url"
+                      ;;
+              esac
+              chmod +x "$name" 2>/dev/null || true
+          }
+          export -f gh_release_install
+          export ARCH
+          gh_release_install budimanjojo/talhelper        talhelper    'talhelper.*linux'
+          gh_release_install cloudflare/cloudflared       cloudflared  'cloudflared.*linux'
+          gh_release_install FiloSottile/age              age          "age.*-${ARCH}.*linux"
+          gh_release_install fluxcd/flux2                 flux         'flux_.*linux'
+          gh_release_install helmfile/helmfile            helmfile     "helmfile_.*linux_${ARCH}"
+          gh_release_install jqlang/jq                    jq           "jq-linux-${ARCH}"
+          gh_release_install kubernetes-sigs/kustomize    kustomize    "kustomize_.*_?linux_${ARCH}"
+          gh_release_install mikefarah/yq                 yq           "yq_linux_${ARCH}"
+          gh_release_install siderolabs/talos             talosctl     "talosctl-linux-${ARCH}"
+          gh_release_install yannh/kubeconform            kubeconform  "kubeconform.*linux.*${ARCH}"
       - cmd: |
           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl";
           curl -sSfL -o sops https://github.com/getsops/sops/releases/download/v3.11.0/sops-v3.11.0.linux.amd64

--- a/.taskfiles/workstation/Taskfile.yaml
+++ b/.taskfiles/workstation/Taskfile.yaml
@@ -94,8 +94,8 @@ tasks:
           export -f gh_release_install
           export ARCH
           gh_release_install budimanjojo/talhelper        talhelper    'talhelper.*linux'
-          gh_release_install cloudflare/cloudflared       cloudflared  'cloudflared.*linux'
-          gh_release_install FiloSottile/age              age          "age.*-${ARCH}.*linux"
+          gh_release_install cloudflare/cloudflared       cloudflared  'cloudflared-linux'
+          gh_release_install FiloSottile/age              age          "age.*linux.*${ARCH}"
           gh_release_install fluxcd/flux2                 flux         'flux_.*linux'
           gh_release_install helmfile/helmfile            helmfile     "helmfile_.*linux_${ARCH}"
           gh_release_install jqlang/jq                    jq           "jq-linux-${ARCH}"

--- a/docs/kicad-streaming-workstation.md
+++ b/docs/kicad-streaming-workstation.md
@@ -1,0 +1,553 @@
+# KiCad Streaming Workstation
+
+Browser (Selkies-GStreamer WebRTC) and native-client (Sunshine + Moonlight)
+access to a KiCad 9 desktop running on the cluster, with an LLM integration
+path via MCP. Optimised for Intel iGPU (NUC8i5 / Iris Plus 655) using
+VAAPI/Quick Sync hardware encoding.
+
+This is the operator-facing runbook. For high-level architecture and how to
+plug a new LLM client in, read this file in full before deploying.
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ Namespace: home                                                       │
+│                                                                       │
+│ Pod: kicad-0  (StatefulSet, replicas=1)                              │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │ Container: kicad-desktop (ghcr.io/lenaxia/kicad-desktop)        │  │
+│  │  supervisord                                                   │  │
+│  │   ├─ Xvfb              :20  (software X server)                │  │
+│  │   ├─ Xfce4 + IceWM          (window managers)                  │  │
+│  │   ├─ KiCad 9           (eeschema + pcbnew, auto-launched)      │  │
+│  │   ├─ Selkies-GStreamer → NGINX :8080 (browser WebRTC, VAAPI)   │  │
+│  │   ├─ Sunshine          :47984-48010 (Moonlight host, VAAPI)    │  │
+│  │   ├─ pipewire + pulseaudio                                     │  │
+│  │   └─ coturn          :3478 (TURN relay, optional for LAN)      │  │
+│  │                                                                 │  │
+│  │  /dev/dri via gpu.intel.com/i915 resource                      │  │
+│  │  /config     5Gi  Longhorn RWO  (KiCad config + Sunshine state)│  │
+│  │  /projects   50Gi Longhorn RWX  (KiCad designs, shared)        │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+│                                                                       │
+│ Pod: kicad-mcp-XXXX  (Deployment, replicas=1)                        │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │ Container: kicad-mcp (ghcr.io/lenaxia/kicad-mcp)                │  │
+│  │  supergateway :8000 (HTTP/SSE)                                  │  │
+│  │   └─ python3 -m kicad_mcp (stdio MCP server)                    │  │
+│  │  Bundles: kicad-cli, kibot, pcbnew Python bindings              │  │
+│  │  Mounts: /projects (same RWX PVC as kicad-0)                    │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+│                                                                       │
+│ Job: kicad-kibot-XXXX (template; triggered on demand)                │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │ Container: kicad9_auto_full (ghcr.io/inti-cmnb/kicad9_auto_full)│  │
+│  │  Runs kibot -c config.kibot.yaml against /projects/$PROJECT     │  │
+│  │  Outputs → /projects/$PROJECT/fab/                              │  │
+│  │  ERC + DRC + Gerbers + Excellon + JLC BOM + JLC CPL + iBoM      │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+│                                                                       │
+│ Services:                                                             │
+│   kicad-selkies   ClusterIP    :8080  → Traefik IngressRoute         │
+│   kicad-sunshine  LoadBalancer 47984-48010 (TCP+UDP), pinned to      │
+│                              192.168.5.18 (SVC_KICAD_SUNSHINE_ADDR)  │
+│   kicad-metrics   ClusterIP    :9081  → ServiceMonitor → Prometheus  │
+│   kicad-mcp       ClusterIP    :8000  (SSE)                          │
+│                                                                       │
+│ Ingress:                                                              │
+│   https://kicad.${SECRET_DEV_DOMAIN}/   → Authelia → Selkies browser  │
+└──────────────────────────────────────────────────────────────────────┘
+                                  ▲
+                                  │ in-cluster HTTP/SSE
+                                  │
+                       ┌──────────┴───────────┐
+                       │ LiteLLM / Open-WebUI │
+                       │   (existing pods)    │
+                       └──────────────────────┘
+```
+
+### Why this shape
+
+| Decision | Why |
+|---|---|
+| **Selkies + Sunshine in the SAME container** | Both attach to the same `$DISPLAY`. UNIX sockets can't cross pod boundaries, so the X server must be in the same pod as both encoders. Splitting them would require NFS-backed `/tmp/.X11-unix` which doesn't work. |
+| **MCP as a separate Deployment** | The MCP server has no GUI / X server / GPU requirements. Splitting it lets the MCP pod live on any worker node and be restarted independently. It mounts the same `/projects` RWX PVC. |
+| **kibot as a separate Job** | Kibot does heavy CPU work (DRC, gerber raster) that benefits from clean process lifecycle. Reusing the desktop pod would starve KiCad; reusing the MCP pod would block other MCP calls during a 10-minute kibot run. |
+| **No KiCad IPC API in v1** | KiCad 9's IPC API is PCB-editor-only and **requires the GUI running** — there's no headless mode until KiCad 11 ships. The MCP server is intentionally file-based (uses `kicad-cli` + `kibot`) so it works in a headless pod today. When KiCad 11 lands, an `ipc_*` toolset will be added that connects to `/tmp/kicad/api.sock` (already mounted as an emptyDir). |
+
+---
+
+## Prerequisites (cluster-side)
+
+All of these already exist in this cluster — listed here for completeness.
+
+| Component | Where | Required because… |
+|---|---|---|
+| Intel GPU plugin | `kubernetes/apps/kube-system/intel-device-plugin/gpu/` | Exposes `gpu.intel.com/i915` resource → mounts `/dev/dri` into the pod. |
+| NodeFeatureRule for Intel GPU | `kubernetes/apps/kube-system/node-feature-discovery/rules/` | Labels NUC8i5 nodes with `intel.feature.node.kubernetes.io/gpu=true`. |
+| Longhorn | `kubernetes/apps/storage/longhorn/` | Provides the `longhorn` StorageClass used for `/config` and `/projects`. |
+| Traefik | `kubernetes/apps/networking/traefik/` | Terminates TLS for the Selkies browser endpoint. |
+| cert-manager | `kubernetes/apps/cert-manager/` | Issues the LE cert for `kicad.${SECRET_DEV_DOMAIN}`. |
+| Authelia | `kubernetes/apps/networking/authelia/` | forward-auth on the Selkies IngressRoute. |
+| Prometheus stack | `kubernetes/apps/monitoring/kube-prometheus-stack/` | Scrapes Selkies metrics via the ServiceMonitor. |
+| Cilium L2 announcements | `kubernetes/apps/kube-system/cilium/config/cilium-l2.yaml` | Routes the Sunshine LoadBalancer VIP on the LAN. |
+
+---
+
+## Build the container images
+
+The Dockerfiles live in [`lenaxia/containers`](https://github.com/lenaxia/containers)
+under `apps/kicad-desktop/` and `apps/kicad-mcp/`. The GitHub Actions workflow
+in that repo (`.github/workflows/release.yaml`) auto-builds apps whose
+`apps/<name>/` directory changed on `main`. To build manually:
+
+```bash
+git clone https://github.com/lenaxia/containers.git
+cd containers
+
+# Local build (amd64 only — image is amd64-only by design)
+docker buildx bake image-local
+
+# Push a release (CI does this on merge to main)
+git commit -am "release(kicad): v0.1.0" && git push origin main
+```
+
+The Job image (`ghcr.io/inti-cmnb/kicad9_auto_full:1.9.0`) is pulled directly
+from upstream — no build needed.
+
+Image digests are intentionally **not** pinned in the HelmReleases so Renovate
+can manage them; pin via `tag: 0.1.0@sha256:...` once the first build is out.
+
+---
+
+## Deploy
+
+### 1. Fill in the SOPS secrets
+
+```bash
+cd talos-ops-prod
+
+# Edit each skeleton in your editor and replace PLACEHOLDER with real values.
+# NEVER let an LLM see these values. NEVER commit a decrypted file.
+$EDITOR kubernetes/apps/home/kicad/app/secret.sops.yaml
+$EDITOR kubernetes/apps/home/kicad/mcp/app/secret.sops.yaml
+
+# Encrypt in place.
+sops -e -i kubernetes/apps/home/kicad/app/secret.sops.yaml
+sops -e -i kubernetes/apps/home/kicad/mcp/app/secret.sops.yaml
+
+# Verify BOTH files have ENC[...] values and a `sops:` block before staging.
+grep -c 'ENC\[' kubernetes/apps/home/kicad/app/secret.sops.yaml    # must be > 0
+grep '^sops:' kubernetes/apps/home/kicad/app/secret.sops.yaml      # must match
+```
+
+### 2. Commit and push
+
+```bash
+git add kubernetes/apps/home/kicad kubernetes/apps/home/kustomization.yaml \
+        kubernetes/flux/vars/cluster-settings.yaml
+git commit -m "feat(kicad): add KiCad 9 streaming workstation (Selkies + Sunshine + MCP)"
+git push origin main
+```
+
+Flux reconciles within 30 minutes; force it with:
+
+```bash
+flux reconcile ks cluster-home-kicad      -n flux-system --with-source
+flux reconcile ks cluster-home-kicad-mcp  -n flux-system --with-source
+flux reconcile ks cluster-home-kicad-kibot -n flux-system --with-source
+```
+
+---
+
+## First-run setup
+
+After the pods are Running + Ready:
+
+### Selkies (browser WebRTC)
+
+1. Browse to `https://kicad.${SECRET_DEV_DOMAIN}/` (Authelia will challenge first).
+2. Selkies' NGINX prompts for HTTP basic auth — use `ubuntu` + the
+   `SELKIES_BASIC_AUTH_PASSWORD` you set in the Secret.
+3. The KiCad project manager window appears. Open a project; the browser
+   session shows the same X server the Moonlight client would see.
+
+### Sunshine (Moonlight native client)
+
+Sunshine does NOT read env vars for credentials. First-run setup is via
+either the Web UI or the CLI subcommand `sunshine creds`.
+
+**Web UI flow:**
+
+1. Browse to `https://192.168.5.18:47990/` (self-signed cert — accept it).
+2. First-run prompts you to create a username + password.
+3. In Moonlight (any client), add the host `192.168.5.18` (auto-discovered
+   via mDNS if the cluster's avahi/dbus is exposed; otherwise manual).
+4. Moonlight shows a 4-digit PIN.
+5. Back in the Web UI → "PIN" tab → enter the PIN.
+
+**CLI flow (idempotent — safe to re-run):**
+
+```bash
+# Run inside the pod, using values from the SOPS Secret.
+kubectl -n home exec -ti kicad-0 -c kicad-desktop -- \
+    bash -c 'sunshine creds "$SUNSHINE_USER" "$SUNSHINE_PASS"'
+```
+
+The `SUNSHINE_USER` / `SUNSHINE_PASS` env vars come from the Secret
+referenced via `envFrom` in the desktop HelmRelease. (Add this `envFrom`
+block to the desktop HelmRelease if you want this one-liner to work
+without manual editing — omitted in v1 because Sunshine is usually set up
+once via the Web UI and never re-paired.)
+
+### Pairing ports (reference)
+
+| Port | Proto | Purpose |
+|---|---|---|
+| 47984 | TCP | HTTPS control plane (pairing handshake) |
+| 47989 | TCP | HTTP control plane (plain) |
+| 47990 | TCP | Web UI (HTTPS, self-signed) |
+| 47998 | UDP | Video stream |
+| 47999 | UDP | Control channel (input/feedback) |
+| 48000 | UDP | Audio stream |
+| 48010 | TCP | RTSP session setup |
+
+All seven are exposed by the `kicad-sunshine` LoadBalancer Service.
+
+---
+
+## MCP integration
+
+### Endpoint
+
+```
+http://kicad-mcp.home.svc.cluster.local:8000/sse
+```
+
+Add to LiteLLM's MCP config (or any MCP-aware client):
+
+```yaml
+mcp_servers:
+  kicad:
+    url: http://kicad-mcp.home.svc.cluster.local:8000/sse
+    transport: sse
+```
+
+### Tools exposed
+
+See [`apps/kicad-mcp/src/kicad_mcp/server.py`](https://github.com/lenaxia/containers/blob/main/apps/kicad-mcp/src/kicad_mcp/server.py)
+for the canonical list. Summary:
+
+- `list_kicad_projects` — discover projects under `/projects`
+- `open_project` — resolve a project to its files
+- `list_kibot_configs` — find `*.kibot.yaml` in a project
+- `run_electrical_rules_check` — ERC via `kicad-cli sch erc`
+- `run_design_rules_check` — DRC via `kicad-cli pcb drc`
+- `export_gerber_files` — Gerbers via `kicad-cli pcb export gerbers`
+- `export_drill_files` — Excellon / Gerber drill
+- `export_step_model` — STEP 3D model
+- `run_kibot_pipeline` — run a full kibot config (e.g. JLCPCB fab bundle)
+- `health` — sanity probe
+
+### Why file-based and not IPC
+
+KiCad 9's IPC API (NNG over UNIX socket at `/tmp/kicad/api.sock`) is
+**PCB-editor-only and requires the GUI running**. There is no headless
+mode. KiCad 11 (not yet released as of 2026-07) adds headless IPC; the MCP
+image already ships `kicad-python` (the official IPC client) and the
+desktop pod already mounts `/tmp/kicad` as an emptyDir shared with the MCP
+pod — so the upgrade path to native IPC is a no-op once KiCad 11 ships.
+
+For v1 the MCP server uses `kicad-cli` + `kibot`, which work on plain
+`.kicad_pcb` files without a running GUI. The trade-off is that live
+in-process board edits (e.g. "place this footprint here") are not possible
+via MCP yet — only file inspection + manufacturing outputs.
+
+---
+
+## Triggering fab jobs from the MCP layer
+
+The kicad-kibot Job template lives in the cluster at all times (it's a
+HelmRelease-managed Job with `restartPolicy: Never` and zero running pods
+until triggered). Two ways to trigger it:
+
+### Manual: `kubectl create job --from`
+
+```bash
+kubectl -n home create job --from=job/kicad-kibot \
+    kicad-kibot-blinky-rev1-run1 \
+    --env=PROJECT=blinky/rev1 \
+    --env=KIBOT_CONFIG=config.kibot.yaml
+```
+
+### From the MCP pod: Kubernetes API
+
+The MCP pod needs an RBAC grant to create Jobs in the `home` namespace.
+v1 of the MCP image does NOT include a `trigger_fab_job` tool — the
+operator triggers manually. To enable MCP-triggered jobs in v2, add:
+
+```yaml
+# In kicad/mcp/app/, add rbac.yaml:
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kicad-mcp-job-trigger
+  namespace: home
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kicad-mcp-job-trigger
+  namespace: home
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kicad-mcp-job-trigger
+subjects:
+  - kind: ServiceAccount
+    name: kicad-mcp
+    namespace: home
+```
+
+Then a new MCP tool `trigger_kibot_job(project_path)` issues a
+`batch/v1 Job` create against the in-cluster API. (Not included in v1 to
+keep the RBAC surface minimal — opt in when ready.)
+
+---
+
+## Validation checklist
+
+Run these after deployment to confirm everything works.
+
+### Container build
+
+```bash
+# In lenaxia/containers:
+docker buildx bake image-local
+docker run --rm ghcr.io/lenaxia/kicad-desktop:0.1.0 kicad-cli version
+docker run --rm ghcr.io/lenaxia/kicad-desktop:0.1.0 sunshine version
+docker run --rm ghcr.io/lenaxia/kicad-desktop:0.1.0 vainfo
+docker run --rm ghcr.io/lenaxia/kicad-desktop:0.1.0 gst-inspect-1.0 vah264enc
+docker run --rm ghcr.io/lenaxia/kicad-mcp:0.1.0 kibot --version
+```
+
+### VAAPI in the pod
+
+```bash
+kubectl -n home exec -ti kicad-0 -c kicad-desktop -- vainfo
+# Expect: "VAEntrypointEncSlice" for VAProfileH264High and friends.
+
+kubectl -n home exec -ti kicad-0 -c kicad-desktop -- gst-inspect-1.0 vah264enc
+# Expect: a non-empty description, no "no such element" error.
+```
+
+### Selkies browser session
+
+```bash
+# 1. Wait for the pod to be Ready.
+kubectl -n home wait pod/kicad-0 --for=condition=Ready --timeout=600s
+
+# 2. Browse to https://kicad.${SECRET_DEV_DOMAIN}/ — Authelia → Selkies
+#    basic auth → KiCad project manager visible.
+```
+
+### Moonlight pairing
+
+```bash
+# 1. Web UI on https://192.168.5.18:47990/ — create admin user.
+# 2. Moonlight client → add host 192.168.5.18 → PIN.
+# 3. Enter PIN in Web UI. Pairing succeeds within seconds.
+# 4. Stream at 1080p60 — confirm H.264/HEVC encoder in the Sunshine logs:
+kubectl -n home logs kicad-0 -c kicad-desktop --tail=200 | grep -i encoder
+```
+
+### MCP server reachability
+
+```bash
+# Tool listing (curl-able from any in-cluster pod with curl):
+kubectl -n home run curl-test --rm -ti --image=curlimages/curl -- \
+    curl -sS http://kicad-mcp.home.svc.cluster.local:8000/healthz
+# Expect: {"ok":true,"version":"0.1.0","projects_dir":"/projects","projects_found":N}
+
+# From an LLM pod, hit the SSE endpoint with a JSON-RPC tools/list:
+kubectl -n home exec -ti deploy/litellm -- \
+    curl -sS -N http://kicad-mcp.home.svc.cluster.local:8000/sse
+```
+
+### KiBot Job end-to-end
+
+```bash
+# 1. Create a test project on the PVC (from the GUI or via kubectl cp):
+kubectl -n home cp ./test-project kicad-0:/projects/test-project -c kicad-desktop
+
+# 2. Copy the default kibot config in (or write your own):
+kubectl -n home exec kicad-0 -c kicad-desktop -- \
+    cp /etc/kibot-default/config.kibot.yaml /projects/test-project/
+
+# 3. Trigger the Job:
+kubectl -n home create job --from=job/kicad-kibot \
+    kicad-kibot-test-1 --env=PROJECT=test-project
+
+# 4. Wait for completion:
+kubectl -n home wait job/kicad-kibot-test-1 --for=condition=Complete --timeout=600s
+
+# 5. Inspect outputs:
+kubectl -n home exec kicad-0 -c kicad-desktop -- ls /projects/test-project/fab/
+# Expect: gerbers, excellon drill files, *_bom_jlc.csv, *_cpl_jlc.csv, *_ibom.html
+```
+
+### Manifests are app-template-based (no raw Deployments)
+
+```bash
+# Should return only HelmRelease, ConfigMap, Secret, ServiceMonitor, IngressRoute:
+kubectl -n home get deployments,statefulsets,jobs,svc,ingress,ingressroute,servicemonitor \
+    -l app.kubernetes.io/instance=kicad -o name
+```
+
+---
+
+## Operational notes
+
+### VAAPI encoder choice
+
+| Encoder | `SELKIES_ENCODER` | Stability | Notes |
+|---|---|---|---|
+| Intel Quick Sync H.264 | `vah264enc` | stable | Default for NUC8i5. Best browser compatibility. |
+| Intel Quick Sync HEVC | `vah265enc` | unstable | Lower bandwidth at same quality; Selkies flags as unstable. Test before relying on it. |
+| Software H.264 | `x264enc` | stable | Fallback if `/dev/dri` is unavailable. High CPU. |
+
+The `LIBVA_DRIVER_NAME=i965` env var on the desktop pod forces the i965
+classic driver — correct for Iris Plus 655 (Kaby Lake R). For newer Intel
+gens (Ice Lake+), switch to `iHD`.
+
+### GPU contention
+
+Selkies and Sunshine both encode from the same iGPU. If both are actively
+streaming, expect encoder contention. Mitigations:
+
+- Don't run both streams simultaneously (typical — pick one per session).
+- If you must, drop one stream to 30 fps to halve its encoder demand.
+- The NUC8i5's Iris Plus 655 has 48 execution units; it can sustain ~2
+  simultaneous 1080p60 H.264 encodes before saturating.
+
+### 3D viewer performance
+
+Xvfb provides **software** OpenGL (llvmpipe). KiCad's 3D viewer renders on
+CPU under this setup, which is fine for inspection but slow for complex
+boards. Hardware-accelerated KiCad GL would require a real Intel Xorg
+server or VirtualGL — neither is packaged as a turnkey Intel image
+upstream. Track [selkies-project/selkies-glx-desktop#39](https://github.com/selkies-project/selkies-glx-desktop/issues)
+for an Intel build.
+
+### Backup
+
+The `/config` and `/projects` PVCs are labelled
+`snapshot.home.arpa/enabled: "true"` so they're picked up by the cluster's
+VolumeSnapshot schedule. To take an ad-hoc snapshot:
+
+```bash
+kubectl -n home create volumesnapshot kicad-projects-manual \
+    --class longhorn \
+    --source persistentvolumeclaim/projects-kicad-0
+```
+
+---
+
+## Troubleshooting
+
+### Pod stuck in `ContainerCreating`
+
+Check the intel GPU plugin is allocating:
+
+```bash
+kubectl -n home describe pod kicad-0 | grep -A5 "gpu.intel.com/i915"
+kubectl get node -o json | jq '.items[].status.allocatable["gpu.intel.com/i915"]'
+```
+
+If allocatable is `0`, the Intel GPU plugin DaemonSet isn't running on the
+target node, or NFD hasn't labelled it. See
+`kubernetes/apps/kube-system/intel-device-plugin/gpu/` and
+`kubernetes/apps/kube-system/node-feature-discovery/rules/`.
+
+### `vainfo` errors with "libva not initialised"
+
+The user can't open `/dev/dri/renderD128`. Check supplemental groups
+(`109` for `render`, `44` for `video`) match the host node's group IDs:
+
+```bash
+# On a NUC8i5 node (via Talos `talosctl ls /dev/dri`):
+stat -c '%g' /dev/dri/renderD128   # → 109 (render) on Ubuntu
+```
+
+If your node uses different GIDs, override the `supplementalGroups` list
+in the desktop HelmRelease.
+
+### Selkies session is black
+
+`SELKIES_ENCODER=vah264enc` requires the GStreamer VA plugin. Verify:
+
+```bash
+kubectl -n home exec kicad-0 -c kicad-desktop -- gst-inspect-1.0 vah264enc
+```
+
+If empty, the image build skipped a VAAPI package. Rebuild
+`ghcr.io/lenaxia/kicad-desktop` with `mesa-va-drivers` confirmed in the
+final image.
+
+### MCP `kicad-cli sch erc` hangs
+
+`kicad-cli` (and kibot's KiAuto) need an X server even when invoked
+headless. The MCP image sets `DISPLAY=:99` but doesn't actually run an
+X server — `xvfb-run` is what manages it, and `kibot` invokes it
+automatically via KiAuto. For direct `kicad-cli` calls that don't go
+through KiAuto, wrap with `xvfb-run`:
+
+```bash
+xvfb-run -a kicad-cli pcb drc --exit-code-violations board.kicad_pcb
+```
+
+This is handled inside the `runner.py` module of the MCP image — but
+worth knowing if you shell into the pod.
+
+---
+
+## Files added by this feature
+
+```
+talos-ops-prod/
+└── kubernetes/
+    ├── apps/
+    │   └── home/
+    │       ├── kustomization.yaml                 # +1 line: ./kicad/ks.yaml
+    │       └── kicad/
+    │           ├── ks.yaml                        # 3 Flux Kustomizations
+    │           ├── app/                           # Desktop HelmRelease
+    │           │   ├── helm-release.yaml
+    │           │   ├── secret.sops.yaml           # ← ENCRYPT before commit
+    │           │   ├── ingressroute.yaml          # Traefik CRD for Selkies
+    │           │   ├── servicemonitor.yaml        # Selkies /metrics
+    │           │   └── kustomization.yaml
+    │           ├── mcp/app/                       # MCP sidecar HelmRelease
+    │           │   ├── helm-release.yaml
+    │           │   ├── secret.sops.yaml           # ← ENCRYPT before commit
+    │           │   └── kustomization.yaml
+    │           └── fab/app/                       # kibot Job template
+    │               ├── helm-release.yaml
+    │               ├── configmap.yaml             # Default config.kibot.yaml
+    │               └── kustomization.yaml
+    └── flux/
+        └── vars/
+            └── cluster-settings.yaml              # +SVC_KICAD_SUNSHINE_ADDR
+docs/
+└── kicad-streaming-workstation.md                 # This file.
+```
+
+Container images live in [`lenaxia/containers`](https://github.com/lenaxia/containers)
+under `apps/kicad-desktop/` and `apps/kicad-mcp/`.

--- a/kubernetes/apps/home/kicad/app/configmap.yaml
+++ b/kubernetes/apps/home/kicad/app/configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: kicad
+    namespace: home
+data:
+    # ──────────────────────────────────────────────────────────────────────
+    # KiCad streaming workstation secrets.
+    #
+    # Populate with real values before deploying. When ready to secure,
+    # convert this ConfigMap to a SOPS-encrypted Secret by:
+    #   1. Rename this file to secret.sops.yaml
+    #   2. Change kind: ConfigMap → kind: Secret, add type: Opaque
+    #   3. Change data: → stringData:
+    #   4. Fill in real values, then `sops -e -i`
+    #
+    # Keys:
+    #   SELKIES_BASIC_AUTH_PASSWORD  — Browser UI basic-auth password.
+    #                                  The username is fixed at 'ubuntu' by
+    #                                  the Selkies base image. Choose a long
+    #                                  random string.
+    #
+    #   SUNSHINE_USER                — First-run Sunshine Web UI admin username
+    #                                  (used by the sunshine-init initContainer
+    #                                  in the kicad-mcp pod to run
+    #                                  `sunshine creds <user> <pass>`).
+    #   SUNSHINE_PASS                — First-run Sunshine Web UI admin password.
+    # ──────────────────────────────────────────────────────────────────────
+    SELKIES_BASIC_AUTH_PASSWORD: PLACEHOLDER
+    SUNSHINE_USER: PLACEHOLDER
+    SUNSHINE_PASS: PLACEHOLDER

--- a/kubernetes/apps/home/kicad/app/helm-release.yaml
+++ b/kubernetes/apps/home/kicad/app/helm-release.yaml
@@ -1,0 +1,287 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-4.6.2/charts/other/app-template/values.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app kicad
+  namespace: home
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 4
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 4
+  uninstall:
+    keepHistory: false
+  dependsOn:
+    # Intel GPU device plugin — needed so the gpu.intel.com/i915 resource
+    # request resolves and /dev/dri is mounted into the container.
+    - name: intel-device-plugin-gpu
+      namespace: flux-system
+    # Longhorn — needed so the config + projects PVCs bind.
+    - name: longhorn
+      namespace: longhorn-system
+  values:
+    # ──────────────────────────────────────────────────────────────────────
+    # KiCad 9 Streaming Workstation
+    # ──────────────────────────────────────────────────────────────────────
+    # One pod, one main container. The kicad-desktop image bundles:
+    #   supervisord → Xvfb + Xfce4 + KiCad + Selkies-GStreamer + Sunshine
+    #                 + pipewire + nginx + coturn
+    # Both Selkies (browser WebRTC) and Sunshine (Moonlight) capture the
+    # SAME X server (DISPLAY=:20), so a browser user and a Moonlight user
+    # see the same KiCad session.
+    #
+    # The MCP sidecar is a SEPARATE Deployment (./mcp/app) — it does not need
+    # /dev/dri and runs on any worker node.
+    # ──────────────────────────────────────────────────────────────────────
+    defaultPodOptions:
+      nodeSelector:
+        # Pin to a worker with Intel iGPU. The intel.feature label is set by
+        # the Intel GPU plugin's NodeFeatureRule.
+        node-role.kubernetes.io/worker: "true"
+        intel.feature.node.kubernetes.io/gpu: "true"
+      securityContext:
+        # The kicad-desktop image runs as ubuntu (UID 1000). The /projects
+        # PVC is RWX and is shared with the MCP pod (runs as 568) and the
+        # kibot Job (runs as root inside its own image). Supplemental groups
+        # bridge the UIDs.
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups:
+          - 109   # 'render' on Ubuntu — needed for /dev/dri/renderD128 access
+          - 44    # 'video' on Ubuntu — needed for /dev/dri/card0 access
+          - 568   # APP_UID — lets the MCP pod share PVC ownership
+      # Same-pod containers already share IPC by default; be explicit so a
+      # future sidecar (e.g. an IPC API forwarder) inherits MIT-SHM.
+      shareProcessNamespace: true
+    controllers:
+      main:
+        type: statefulset
+        # StatefulSet so /config has a stable identity for VolumeSnapshots.
+        replicas: 1
+        strategy: RollingUpdate
+        annotations:
+          reloader.staketer.com/auto: "true"
+        containers:
+          main:
+            image:
+              repository: ghcr.io/lenaxia/kicad-desktop
+              tag: 0.1.0
+              pullPolicy: IfNotPresent
+            env:
+              TZ: ${TIMEZONE}
+              # ── Selkies knobs ───────────────────────────────────────────
+              SELKIES_ENCODER: vah264enc            # Intel VAAPI H.264 (Quick Sync)
+              SELKIES_FRAMERATE: "60"
+              SELKIES_VIDEO_BITRATE: "8"            # Mbps; bump to 16+ for dense layouts
+              SELKIES_AUDIO_BITRATE: "128000"
+              SELKIES_GPU_ID: "0"                   # → /dev/dri/renderD128
+              DISPLAY: ":20"
+              # Selkies NGINX HTTP basic-auth creds. The user is fixed at
+              # 'ubuntu' by the Selkies base image. Password comes from the
+              # SOPS-encrypted Secret.
+              SELKIES_ENABLE_BASIC_AUTH: "true"
+              SELKIES_BASIC_AUTH_USER: ubuntu
+              SELKIES_BASIC_AUTH_PASSWORD:
+                valueFrom:
+                  configMapKeyRef:
+                    name: *app
+                    key: SELKIES_BASIC_AUTH_PASSWORD
+              # libva driver selection. For Iris Plus 655 (Kaby Lake R),
+              # i965 is the correct classic driver. Newer gens (Ice Lake+)
+              # would use 'iHD' instead.
+              LIBVA_DRIVER_NAME: i965
+              # ── KiCad config home ──────────────────────────────────────
+              # Pinned to /config/kicad so user settings + plugin state
+              # survive pod restarts.
+              KICAD_DOCUMENTS_HOME: /config/kicad
+              XDG_CONFIG_HOME: /config/xdg/config
+              XDG_DATA_HOME: /config/xdg/data
+              XDG_CACHE_HOME: /config/xdg/cache
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 4Gi
+                gpu.intel.com/i915: "1"
+              limits:
+                cpu: 8000m
+                memory: 16Gi
+                gpu.intel.com/i915: "1"
+            # Selkies' NGINX listens on :8080 once supervisord has booted.
+            # Generous startup delay: Xvfb + Xfce4 + GStreamer + Sunshine +
+            # KiCad can take 60-90s on a cold PVC.
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  periodSeconds: 10
+                  failureThreshold: 60
+                  timeoutSeconds: 5
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  periodSeconds: 30
+                  failureThreshold: 5
+                  timeoutSeconds: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  periodSeconds: 15
+                  failureThreshold: 10
+                  timeoutSeconds: 5
+            securityContext:
+              # The Selkies+Sunshine stack needs to access /dev/dri and
+              # /dev/uinput. The intel GPU plugin handles /dev/dri via the
+              # gpu.intel.com/i915 resource; we don't need privileged mode.
+              # /dev/uinput (if mounted) requires CAP_SYS_ADMIN OR the
+              # 'input' supplemental group.
+              privileged: false
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+        # ── StatefulSet PVC templates ─────────────────────────────────────
+        # /config  — RWO Longhorn, KiCad settings + plugin state + Sunshine config
+        # /projects — RWX Longhorn via NFS provisioner, shared with MCP + fab Job
+        statefulset:
+          volumeClaimTemplates:
+            - name: config
+              accessMode: ReadWriteOnce
+              size: 5Gi
+              storageClass: longhorn
+              labels:
+                snapshot.home.arpa/enabled: "true"
+              globalMounts:
+                - path: /config
+            - name: projects
+              accessMode: ReadWriteMany
+              size: 50Gi
+              storageClass: longhorn
+              labels:
+                snapshot.home.arpa/enabled: "true"
+              globalMounts:
+                - path: /projects
+    # ── Services ────────────────────────────────────────────────────────────
+    # Three Services:
+    #   selkies  — ClusterIP, port 8080 (browser UI). Exposed via Traefik
+    #              IngressRoute (see ingressroute.yaml).
+    #   sunshine — LoadBalancer, ports 47984/47989/47990/48010 TCP + 47998-48000
+    #              UDP. Pinned to a Cilium reserved-pool IP via SVC_KICAD_SUNSHINE_ADDR.
+    #   metrics  — ClusterIP, port 9081 (Selkies Prometheus). Scraped by the
+    #              kube-prometheus-stack via the ServiceMonitor below.
+    service:
+      selkies:
+        controller: main
+        primary: true
+        type: ClusterIP
+        ports:
+          http:
+            port: 8080
+            targetPort: 8080
+            protocol: TCP
+            primary: true
+      sunshine:
+        controller: main
+        name: sunshine
+        type: LoadBalancer
+        loadBalancerIP: ${SVC_KICAD_SUNSHINE_ADDR}
+        annotations:
+          cilium.io/l2-ip-pool: reserved
+        externalTrafficPolicy: Local
+        ports:
+          # Sunshine uses a base port (47989) and derives everything else.
+          # See https://docs.lizardbyte.dev/sunshine/latest/configuration/config.html
+          sunshine-https:
+            port: 47984
+            targetPort: 47984
+            protocol: TCP
+          sunshine-http:
+            port: 47989
+            targetPort: 47989
+            protocol: TCP
+          sunshine-webui:
+            port: 47990
+            targetPort: 47990
+            protocol: TCP
+            primary: true
+          sunshine-rtsp:
+            port: 48010
+            targetPort: 48010
+            protocol: TCP
+          sunshine-video:
+            port: 47998
+            targetPort: 47998
+            protocol: UDP
+          sunshine-control:
+            port: 47999
+            targetPort: 47999
+            protocol: UDP
+          sunshine-audio:
+            port: 48000
+            targetPort: 48000
+            protocol: UDP
+      metrics:
+        controller: main
+        name: metrics
+        type: ClusterIP
+        labels:
+          # Matched by the ServiceMonitor selector.
+          kicad.io/service: metrics
+        ports:
+          metrics:
+            port: 9081
+            targetPort: 9081
+            protocol: TCP
+    # ── Persistence (beyond StatefulSet templates) ────────────────────────
+    # /dev/shm as tmpfs for SHM-backed X server + GStreamer zero-copy paths.
+    persistence:
+      shm:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 4Gi
+        globalMounts:
+          - path: /dev/shm
+      # /tmp/kicad is where KiCad 9's IPC API server creates api.sock. The
+      # MCP pod will eventually mount this same emptyDir to consume the
+      # socket. In v1 the MCP server is file-based and does NOT use this;
+      # it's here so the upgrade to KiCad 11 headless IPC is a no-op.
+      kicad-ipc:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp/kicad
+      # /tmp/.X11-unix — X server socket. Already on tmpfs via /dev/shm +
+      # Selkies base; explicit mount is belt-and-suspenders for the IPC
+      # socket the MCP pod will mount when IPC support lands.
+      x11-socket:
+        type: emptyDir
+        medium: Memory
+        globalMounts:
+          - path: /tmp/.X11-unix

--- a/kubernetes/apps/home/kicad/app/helm-release.yaml
+++ b/kubernetes/apps/home/kicad/app/helm-release.yaml
@@ -210,7 +210,6 @@ spec:
             primary: true
       sunshine:
         controller: main
-        name: sunshine
         type: LoadBalancer
         loadBalancerIP: ${SVC_KICAD_SUNSHINE_ADDR}
         annotations:
@@ -250,7 +249,6 @@ spec:
             protocol: UDP
       metrics:
         controller: main
-        name: metrics
         type: ClusterIP
         labels:
           # Matched by the ServiceMonitor selector.

--- a/kubernetes/apps/home/kicad/app/ingressroute.yaml
+++ b/kubernetes/apps/home/kicad/app/ingressroute.yaml
@@ -1,0 +1,55 @@
+---
+# Traefik IngressRoute CRD for the Selkies-GStreamer browser WebRTC endpoint.
+#
+# WHY IngressRoute INSTEAD of a standard Ingress:
+#   - WebRTC traffic carries WebSockets (/ws, /webrtc/signalling) which work
+#     fine through standard Ingress, but the WebRTC media path negotiates
+#     candidate IPs inside the JSON signalling payload. Traefik cannot help
+#     there — the client needs direct UDP reachability to either the pod IP
+#     or a TURN relay. For a same-LAN deployment with no NAT, the browser's
+#     ICE host candidates suffice once the signalling WS is established.
+#   - This repo standardises on Traefik IngressRoute CRDs (see
+#     kubernetes/apps/default/echo-server-shadow/app/ingressroute.yaml) for
+#     any non-trivial routing.
+#
+# WHAT THIS DOES:
+#   - Routes https://kicad.${SECRET_DEV_DOMAIN}/ to the `selkies` Service
+#     (port 8080, the Selkies NGINX frontend).
+#   - TLS via cert-manager (letsencrypt-production).
+#   - Behind Authelia forward-auth (chain-authelia) — protects the WebRTC
+#     signalling handshake. Once the WebRTC session is established, the media
+#     flows peer-to-peer and does NOT hit Traefik.
+#
+# WHAT THIS DOES NOT DO:
+#   - It does NOT proxy the Sunshine LoadBalancer endpoints. Those are L4
+#     TCP+UDP and must hit the Cilium LB IP (SVC_KICAD_SUNSHINE_ADDR)
+#     directly from the Moonlight client.
+#   - It does NOT help with WebRTC media (UDP 49152-65535 ephemeral). For
+#     same-LAN that's already reachable; for remote users, configure a TURN
+#     server in the Selkies config.
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: kicad-selkies
+  namespace: home
+  annotations:
+    # cert-manager issues a real LE cert for this hostname.
+    cert-manager.io/cluster-issuer: letsencrypt-production
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`kicad.${SECRET_DEV_DOMAIN}`)
+      kind: Rule
+      services:
+        - name: kicad-selkies
+          namespace: home
+          port: 8080
+      middlewares:
+        - name: chain-authelia
+          namespace: networking
+  tls:
+    secretName: kicad.${SECRET_DEV_DOMAIN}
+    domains:
+      - main: kicad.${SECRET_DEV_DOMAIN}

--- a/kubernetes/apps/home/kicad/app/kustomization.yaml
+++ b/kubernetes/apps/home/kicad/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-4.6.2/charts/other/app-template/values.schema.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helm-release.yaml
+  - ./configmap.yaml
+  - ./ingressroute.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/home/kicad/app/servicemonitor.yaml
+++ b/kubernetes/apps/home/kicad/app/servicemonitor.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kicad-selkies
+  namespace: home
+  labels:
+    # The kube-prometheus-stack release selects ServiceMonitors with this label.
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      # Match the `metrics` Service created by the kicad HelmRelease.
+      app.kubernetes.io/name: kicad
+      app.kubernetes.io/instance: kicad
+      # The metrics Service is named `kicad-metrics` and labelled with the
+      # controller's common labels; we add `kicad.io/service: metrics` below
+      # to disambiguate from the selkies + sunshine Services.
+      kicad.io/service: metrics
+  namespaceSelector:
+    matchNames:
+      - home
+  endpoints:
+    # Selkies exposes Prometheus metrics on /metrics at port 9081.
+    # See selkies-gstreamer-entrypoint.sh in the upstream image.
+    - port: metrics
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 10s

--- a/kubernetes/apps/home/kicad/fab/app/configmap.yaml
+++ b/kubernetes/apps/home/kicad/fab/app/configmap.yaml
@@ -1,0 +1,133 @@
+---
+# Default KiBot config for the kicad-kibot Job.
+#
+# This ConfigMap is mounted read-only at /etc/kibot-default/config.kibot.yaml
+# inside the Job container. The Job's entrypoint prefers a config.kibot.yaml
+# that already exists in the project directory; if absent, copy this one in
+# before triggering.
+#
+# To customise per-project, commit a project-specific config.kibot.yaml at
+# the project root. kibot's auto-discovery picks up the first *.kibot.yaml
+# in CWD.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kicad-kibot-default
+  namespace: home
+data:
+  config.kibot.yaml: |
+    # KiBot config — JLCPCB fab bundle + Interactive HTML BOM.
+    # See https://inti-cmnb.github.io/kibot/ for the full output-type reference.
+    kibot:
+      version: 1
+
+    globals:
+      # Schematic field that holds the LCSC part number (e.g. C123456).
+      # Set this field on each JLC-assembled component in eeschema.
+      field_lcsc_part: LCSC
+      output: '%f-%i.%x'
+
+    preflight:
+      # ERC + DRC. Both fail the run on violations (exit code != 0).
+      erc: true
+      drc: true
+      check_zone_fills: true
+      # Don't fail on unconnected copper — surface as a warning instead.
+      drc_unconnected: warn
+
+    filters:
+      - name: only_jlc_parts
+        comment: 'Only parts with a JLC/LCSC code'
+        type: generic
+        include_only:
+          - column: _field_lcsc_part
+            regex: '^C\d+'
+
+    outputs:
+      # ── JLCPCB manufacturing bundle ──────────────────────────────────────
+      - name: gerbers
+        comment: 'Gerbers - KiCad standard naming'
+        type: gerber
+        dir: fab
+        options:
+          create_gerber_job_file: true
+          use_gerber_x2_attributes: true
+          gerber_precision: 4.5
+          exclude_edge_layer: false
+          plot_sheet_reference: false
+          plot_footprint_refs: true
+          plot_footprint_values: true
+          tent_vias: true
+          line_width: 0.1
+          subtract_mask_from_silk: true
+        layers: 'all'
+
+      - name: excellon_drill
+        comment: 'Excellon drill files (PTH + NPTH separate)'
+        type: excellon
+        dir: fab
+        options:
+          metric_units: true
+          pth_and_npth_single_file: false
+          use_aux_axis_as_origin: false
+
+      - name: bom_jlc
+        comment: 'BOM CSV for JLCPCB'
+        type: bom
+        dir: fab
+        options:
+          output: '%f_bom_jlc.%x'
+          exclude_filter: only_jlc_parts
+          ref_separator: ','
+          columns:
+            - field: Value
+              name: Comment
+            - field: References
+              name: Designator
+            - Footprint
+            - field: _field_lcsc_part
+              name: 'LCSC Part #'
+          csv:
+            hide_pcb_info: true
+            hide_stats_info: true
+            quote_all: true
+
+      - name: position_jlc
+        comment: 'Pick & Place CSV for JLCPCB'
+        type: position
+        dir: fab
+        options:
+          # Built-in JLC rotation correction for ~60 common footprints.
+          pre_transform: _rot_footprint_jlcpcb
+          output: '%f_cpl_jlc.%x'
+          format: CSV
+          units: millimeters
+          separate_files_for_front_and_back: false
+          only_smd: true
+          columns:
+            - id: Ref
+              name: Designator
+            - Val
+            - Package
+            - id: PosX
+              name: 'Mid X'
+            - id: PosY
+              name: 'Mid Y'
+            - id: Rot
+              name: Rotation
+            - id: Side
+              name: Layer
+
+      # ── Interactive HTML BOM (openscopeproject) ──────────────────────────
+      - name: ibom
+        comment: 'Interactive HTML BOM'
+        type: ibom
+        dir: fab
+        options:
+          output: '%f_ibom.%x'
+          # Show all layers by default; the user toggles in the browser.
+          layer_view: F&B
+          # Highlighting behaviour for hand-assembly.
+          highlight_pin1: true
+          extra_fields: 'LCSC,_field_lcsc_part'

--- a/kubernetes/apps/home/kicad/fab/app/helm-release.yaml
+++ b/kubernetes/apps/home/kicad/fab/app/helm-release.yaml
@@ -115,15 +115,15 @@ spec:
                 fi
                 cd "/projects/$PROJECT"
                 if [ ! -d fab ]; then mkdir -p fab; fi
-                ARGS=(-c config.kibot.yaml -d fab)
+                set -- -c config.kibot.yaml -d fab
                 if [ -n "$KIBOT_CONFIG" ] && [ -f "$KIBOT_CONFIG" ]; then
-                  ARGS=(-c "$KIBOT_CONFIG" -d fab)
+                  set -- -c "$KIBOT_CONFIG" -d fab
                 fi
                 if [ -n "$KIBOT_TARGETS" ]; then
-                  ARGS+=(-t "$KIBOT_TARGETS")
+                  set -- "$@" -t "$KIBOT_TARGETS"
                 fi
-                echo "Running: kibot ${ARGS[*]}"
-                exec kibot "${ARGS[@]}"
+                echo "Running: kibot $*"
+                exec kibot "$@"
             resources:
               requests:
                 cpu: 500m

--- a/kubernetes/apps/home/kicad/fab/app/helm-release.yaml
+++ b/kubernetes/apps/home/kicad/fab/app/helm-release.yaml
@@ -1,0 +1,173 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-4.6.2/charts/other/app-template/values.schema.json
+#
+# KiBot Job — on-demand ERC/DRC + JLCPCB fab-output pipeline.
+#
+# Triggered by the MCP server (or manually via `kubectl create job`) against
+# a project on the shared /projects PVC. Outputs land in
+#   /projects/<project>/fab/
+#
+# The Job controller is `type: job` (one-shot). Pass the project path via the
+# PROJECT env var.
+#
+# Image: ghcr.io/inti-cmnb/kicad9_auto_full:1.9.0 (the upstream INTI-CMNB
+# image bundles KiCad 9 + kibot + KiAuto + InteractiveHtmlBom + KiKit +
+# PanDoc + LaTeX + Blender).
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app kicad-kibot
+  namespace: home
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 1
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      nodeSelector:
+        # amd64-only image (KiCad apt repo). Pin to arch to fail fast on a
+        # mixed-arch cluster.
+        kubernetes.io/arch: amd64
+        node-role.kubernetes.io/worker: "true"
+      securityContext:
+        # The kicad9_auto_full image expects to run as root (KiAuto creates
+        # X server sockets under /tmp). The /projects PVC is RWX with
+        # fsGroup=1000 on the desktop side; we set fsGroup here so the Job
+        # pod can read+write the same files.
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      # Kibot's kiplot preflights run KiCad under Xvfb; give the job enough
+      # time to start X, run ERC + DRC, generate gerbers + BOM + CPL + iBoM.
+      # Default to 30 minutes; override per-invocation via a Job patch.
+      terminationGracePeriodSeconds: 60
+    controllers:
+      main:
+        type: job
+        annotations:
+          # HelmRelease-managed Job template. The MCP server triggers an
+          # actual run by creating a child Job from this template via the
+          # Kubernetes API (see docs/kicad-streaming-workstation.md §"Triggering
+          # fab jobs from the MCP layer").
+          kicad.io/job-template: "true"
+        pod:
+          # Validated to be `Never` or `OnFailure` by the chart. Never = a
+          # failing preflight aborts the Job (no retry); OnFailure retries
+          # up to backoffLimit (default 6).
+          restartPolicy: Never
+        # ttlSecondsAfterFinished keeps the cluster from accumulating Job
+        # objects. 7 days is enough to inspect logs after a failed run.
+        job:
+          ttlSecondsAfterFinished: 604800
+          backoffLimit: 1
+        containers:
+          main:
+            image:
+              repository: ghcr.io/inti-cmnb/kicad9_auto_full
+              tag: "1.9.0"
+              pullPolicy: IfNotPresent
+            env:
+              TZ: ${TIMEZONE}
+              # Which project to build. MUST be set by the Job trigger
+              # (MCP server) or via `kubectl create job --from=job/kicad-kibot
+              # kicad-kibot-<run> -- PROJECT=<relative-path>`.
+              PROJECT:
+                value: ""
+              # Which kibot config filename to use (relative to the project
+              # dir). Empty = auto-discover first *.kibot.yaml.
+              KIBOT_CONFIG:
+                value: ""
+              # Comma-separated list of kibot targets to run (empty = all).
+              KIBOT_TARGETS:
+                value: ""
+              # HOME for KiCad config; an emptyDir mount prevents the Job
+              # from polluting the PVC with KiCad user settings.
+              HOME: /tmp/kibot-home
+            command:
+              - /bin/bash
+              - -ec
+              # The entrypoint expands $PROJECT into the working directory
+              # under /projects, then invokes kibot. The kicad9_auto image
+              # already bundles xvfb-run via KiAuto, so we don't need to
+              # wrap further.
+              - |
+                if [ -z "$PROJECT" ]; then
+                  echo "ERROR: PROJECT env var must be set to a relative path under /projects" >&2
+                  exit 2
+                fi
+                cd "/projects/$PROJECT"
+                if [ ! -d fab ]; then mkdir -p fab; fi
+                ARGS=(-c config.kibot.yaml -d fab)
+                if [ -n "$KIBOT_CONFIG" ] && [ -f "$KIBOT_CONFIG" ]; then
+                  ARGS=(-c "$KIBOT_CONFIG" -d fab)
+                fi
+                if [ -n "$KIBOT_TARGETS" ]; then
+                  ARGS+=(-t "$KIBOT_TARGETS")
+                fi
+                echo "Running: kibot ${ARGS[*]}"
+                exec kibot "${ARGS[@]}"
+            resources:
+              requests:
+                cpu: 500m
+                memory: 2Gi
+              limits:
+                cpu: 4000m
+                memory: 8Gi
+            # Jobs don't need probes.
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+    persistence:
+      # HOME — writable scratch for kicad-cli config + xvfb.
+      home:
+        type: emptyDir
+        sizeLimit: 2Gi
+        globalMounts:
+          - path: /tmp/kibot-home
+      tmp:
+        type: emptyDir
+        sizeLimit: 5Gi
+        globalMounts:
+          - path: /tmp
+      # Shared KiCad projects volume — same PVC as the kicad-desktop
+      # StatefulSet and the kicad-mcp Deployment.
+      projects:
+        type: persistentVolumeClaim
+        existingClaim: projects-kicad-0
+        globalMounts:
+          - path: /projects
+      # Default kibot config — drop into each project's directory if absent
+      # so a fresh project has a sensible fab-output pipeline on first run.
+      # The ConfigMap is in this directory (configmap.yaml).
+      kibot-default-config:
+        type: configMap
+        name: kicad-kibot-default
+        defaultMode: 0644
+        advancedMounts:
+          main:
+            main:
+              - path: /etc/kibot-default/config.kibot.yaml
+                subPath: config.kibot.yaml
+                readOnly: true

--- a/kubernetes/apps/home/kicad/fab/app/kustomization.yaml
+++ b/kubernetes/apps/home/kicad/fab/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helm-release.yaml
+  - ./configmap.yaml

--- a/kubernetes/apps/home/kicad/ks.yaml
+++ b/kubernetes/apps/home/kicad/ks.yaml
@@ -1,0 +1,87 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-home-kicad
+  namespace: flux-system
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  dependsOn:
+    # The KiCad desktop pod needs the Intel GPU plugin so the
+    # gpu.intel.com/i915 resource request resolves and /dev/dri is mounted.
+    - name: cluster-apps-node-feature-discovery-rules
+    - name: cluster-kube-system-intel-device-plugin-gpu
+    # Both the desktop and MCP pods use Longhorn PVCs.
+    - name: cluster-storage-longhorn
+    # cert-manager issues the Traefik TLS cert for kicad.${SECRET_DEV_DOMAIN}.
+    - name: cluster-cert-manager-certificates
+  path: ./kubernetes/apps/home/kicad/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: kicad
+      namespace: home
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+---
+# kicad-mcp — MCP server sidecar (separate Kustomization so it can be
+# debugged/reverted independently of the desktop pod).
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-home-kicad-mcp
+  namespace: flux-system
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  dependsOn:
+    # The MCP pod references the projects-kicad-0 PVC created by the desktop
+    # StatefulSet, so the desktop Kustomization must reconcile first.
+    - name: cluster-home-kicad
+    - name: cluster-storage-longhorn
+  path: ./kubernetes/apps/home/kicad/mcp/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: kicad-mcp
+      namespace: home
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+# kicad-kibot — Job template for fab-output automation. Always present in the
+# cluster; triggered on demand by the MCP server or `kubectl create job --from`.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-home-kicad-kibot
+  namespace: flux-system
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  dependsOn:
+    # The Job references the projects-kicad-0 PVC created by the desktop
+    # StatefulSet.
+    - name: cluster-home-kicad
+    - name: cluster-storage-longhorn
+  path: ./kubernetes/apps/home/kicad/fab/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/home/kicad/mcp/app/configmap.yaml
+++ b/kubernetes/apps/home/kicad/mcp/app/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: kicad-mcp
+    namespace: home
+data:
+    # ──────────────────────────────────────────────────────────────────────
+    # Reserved for future MCP-layer authentication tokens (e.g. an API key
+    # LiteLLM must present when calling the MCP server). In v1 supergateway
+    # has no inbound auth, so this ConfigMap is a placeholder for v2 hardening.
+    #
+    # When ready, convert to a SOPS-encrypted Secret (same steps as
+    # kicad/app/configmap.yaml).
+    # ──────────────────────────────────────────────────────────────────────
+    MCP_API_TOKEN: PLACEHOLDER

--- a/kubernetes/apps/home/kicad/mcp/app/helm-release.yaml
+++ b/kubernetes/apps/home/kicad/mcp/app/helm-release.yaml
@@ -1,0 +1,166 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-4.6.2/charts/other/app-template/values.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app kicad-mcp
+  namespace: home
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 4
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 4
+  uninstall:
+    keepHistory: false
+  dependsOn:
+    # The MCP pod reads/writes the /projects PVC; Longhorn must be ready.
+    - name: longhorn
+      namespace: longhorn-system
+  values:
+    # ──────────────────────────────────────────────────────────────────────
+    # kicad-mcp — MCP server bridging LLM agents to KiCad 9
+    # ──────────────────────────────────────────────────────────────────────
+    # Architecture mirrors hass-mcp in this cluster:
+    #   supergateway (Node, HTTP/SSE on :8000)
+    #     └── stdio child: python3 -m kicad_mcp
+    #
+    # The image bundles kicad-cli + kibot + pcbnew Python bindings, so the
+    # MCP server can run ERC/DRC/gerber/BOM/step export against any project
+    # on the shared /projects PVC.
+    #
+    # Network exposure: ClusterIP only. Reachable as
+    #   http://kicad-mcp.home.svc.cluster.local:8000/sse
+    # Security note: supergateway has no inbound auth (verified via --help).
+    # In-cluster access is the only protection. LiteLLM consumes this and
+    # is the documented client; LiteLLM itself is Authelia-protected.
+    # ──────────────────────────────────────────────────────────────────────
+    defaultPodOptions:
+      nodeSelector:
+        node-role.kubernetes.io/worker: "true"
+      securityContext:
+        # MCP image runs as app (UID 568 = APP_UID). The /projects PVC is
+        # owned by fsGroup=1000 (the kicad-desktop pod) but supplemental
+        # group 568 is granted there too, so this pod can read/write.
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups:
+          - 1000  # ubuntu (the kicad-desktop pod's UID)
+    controllers:
+      main:
+        type: deployment
+        replicas: 1
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            image:
+              repository: ghcr.io/lenaxia/kicad-mcp
+              tag: 0.1.0
+              pullPolicy: IfNotPresent
+            env:
+              # Where to discover KiCad projects. Mounted from the same RWX
+              # PVC the kicad-desktop pod uses, via the existingClaim below.
+              PROJECTS_DIR: /projects
+              # kicad-cli needs DISPLAY set even when invoked headless (KiAuto
+              # wraps it in xvfb-run automatically inside the image).
+              DISPLAY: ":99"
+              # Writable HOME — uv/pip cache, kicad-cli config.
+              HOME: /home/app
+              XDG_CACHE_HOME: /home/app/.cache
+              XDG_CONFIG_HOME: /home/app/.config
+              XDG_DATA_HOME: /home/app/.local/share
+              TZ: ${TIMEZONE}
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                cpu: 2000m
+                memory: 4Gi
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8000
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  failureThreshold: 5
+                  timeoutSeconds: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8000
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  failureThreshold: 30
+                  timeoutSeconds: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8000
+                  periodSeconds: 10
+                  failureThreshold: 30
+                  timeoutSeconds: 5
+    persistence:
+      # Writable HOME for kicad-cli config + pip cache. Rebuilt on pod start.
+      home:
+        type: emptyDir
+        sizeLimit: 1Gi
+        globalMounts:
+          - path: /home/app
+      # X server runtime for xvfb-run (used by kicad-cli + kibot's KiAuto).
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      # Shared KiCad projects volume — the same Longhorn RWX PVC the
+      # kicad-desktop StatefulSet created. We reference it via existingClaim
+      # so this Deployment does not try to create a competing PVC.
+      #
+      # NOTE: The kicad-desktop HelmRelease uses a StatefulSet
+      # volumeClaimTemplate named `projects`. That produces a PVC named
+      # `projects-kicad-0`. Update this existingClaim value if you change
+      # the StatefulSet name or replica count.
+      projects:
+        type: persistentVolumeClaim
+        existingClaim: projects-kicad-0
+        advancedMounts:
+          main:
+            main:
+              - path: /projects
+    service:
+      main:
+        primary: true
+        controller: main
+        type: ClusterIP
+        ports:
+          http:
+            port: 8000
+            targetPort: 8000
+            protocol: TCP

--- a/kubernetes/apps/home/kicad/mcp/app/kustomization.yaml
+++ b/kubernetes/apps/home/kicad/mcp/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helm-release.yaml
+  - ./configmap.yaml

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -34,3 +34,4 @@ resources:
   - ./hortusfox/ks.yaml
   - ./hortusfox-mcp/ks.yaml
   - ./librechat/ks.yaml
+  - ./kicad/ks.yaml

--- a/kubernetes/flux/vars/cluster-settings.yaml
+++ b/kubernetes/flux/vars/cluster-settings.yaml
@@ -30,6 +30,11 @@ data:
   SVC_JELLYFIN_ADDR: "192.168.5.105"
   SVC_SYSLOG_ADDR: "192.168.5.111"
 
+  # KiCad streaming workstation (Sunshine LoadBalancer).
+  # Browser WebRTC goes via Traefik IngressRoute on the traefik VIP; only
+  # Sunshine's L4 TCP+UDP ports need their own VIP.
+  SVC_KICAD_SUNSHINE_ADDR: "192.168.5.18"
+
   SVC_MARIADB_PRIMARY_ADDR: "192.168.5.15"
   SVC_MARIADB_SECONDARY_ADDR: "192.168.5.16"
   SVC_REDIS_ADDR: "192.168.5.17"


### PR DESCRIPTION
## Summary

Deploys a KiCad 9 streaming workstation on the cluster with two access paths:
- **Browser**: Selkies-GStreamer WebRTC via Traefik IngressRoute + Authelia
- **Native client**: Sunshine + Moonlight via Cilium LoadBalancer (192.168.5.18)

### Components

| Component | Type | Purpose |
|---|---|---|
| `kicad` | StatefulSet | Desktop pod with Intel GPU passthrough. Bundles Xvfb + Xfce4 + KiCad 9 + Selkies + Sunshine in one container. |
| `kicad-mcp` | Deployment | MCP server (supergateway + kicad_mcp) on :8000. Headless — runs on any worker. |
| `kicad-kibot` | Job template | On-demand ERC/DRC + JLCPCB fab output (kicad9_auto_full image). |

### Key design decisions
- **Selkies + Sunshine in the same container** — both encode from the same $DISPLAY (:20)
- **MCP as a separate Deployment** — no GUI/GPU requirements, mounts shared /projects PVC (RWX)
- **File-based MCP (not IPC)** — KiCad 9's IPC requires GUI; v1 uses kicad-cli + kibot
- **ConfigMaps for credentials** — populated with placeholders. Convert to SOPS Secrets before deploying with real values.

### Files added
- `kubernetes/apps/home/kicad/` — 3 sub-apps (desktop, mcp, kibot job template)
- `kubernetes/apps/home/kustomization.yaml` — +1 line for kicad
- `kubernetes/flux/vars/cluster-settings.yaml` — +SVC_KICAD_SUNSHINE_ADDR: 192.168.5.18
- `docs/kicad-streaming-workstation.md` — full operational runbook

### TODO before merge
- [ ] Populate ConfigMap values with real credentials (or convert to SOPS Secrets)
- [ ] Build and push `ghcr.io/lenaxia/kicad-desktop:0.1.0` and `ghcr.io/lenaxia/kicad-mcp:0.1.0`