### PR TITLE
fix(kicad): correct Flux dependency names to unblock reconciliation

### DIFF
--- a/kubernetes/apps/home/kicad/app/helm-release.yaml
+++ b/kubernetes/apps/home/kicad/app/helm-release.yaml
@@ -30,7 +30,7 @@ spec:
     # Intel GPU device plugin — needed so the gpu.intel.com/i915 resource
     # request resolves and /dev/dri is mounted into the container.
     - name: intel-device-plugin-gpu
-      namespace: flux-system
+      namespace: kube-system
     # Longhorn — needed so the config + projects PVCs bind.
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/home/kicad/ks.yaml
+++ b/kubernetes/apps/home/kicad/ks.yaml
@@ -12,11 +12,11 @@ spec:
     # The KiCad desktop pod needs the Intel GPU plugin so the
     # gpu.intel.com/i915 resource request resolves and /dev/dri is mounted.
     - name: cluster-apps-node-feature-discovery-rules
-    - name: cluster-kube-system-intel-device-plugin-gpu
+    - name: cluster-apps-intel-device-plugin-gpu
     # Both the desktop and MCP pods use Longhorn PVCs.
     - name: cluster-storage-longhorn
     # cert-manager issues the Traefik TLS cert for kicad.${SECRET_DEV_DOMAIN}.
-    - name: cluster-cert-manager-certificates
+    - name: cert-manager-issuers
   path: ./kubernetes/apps/home/kicad/app
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary

The KiCad Kustomizations from #2015 were stuck with `dependency not found` errors because the `dependsOn` names didn't match the actual deployed Flux resources:

| ks.yaml referenced | Actual KS name |
|---|---|
| `cluster-kube-system-intel-device-plugin-gpu` | `cluster-apps-intel-device-plugin-gpu` |
| `cluster-cert-manager-certificates` | `cert-manager-issuers` |

The desktop `helm-release.yaml` also referenced `intel-device-plugin-gpu` HelmRelease in `flux-system`, but it's deployed in `kube-system`.

This blocked all three kicad Kustomizations (`cluster-home-kicad`, `cluster-home-kicad-mcp`, `cluster-home-kicad-kibot`) from reconciling.

Follow-up to #2016 (#2017).