### PR TITLE
fix(kicad): use correct GHCR tag for kicad-desktop image

### DIFF
--- a/kubernetes/apps/home/kicad/app/helm-release.yaml
+++ b/kubernetes/apps/home/kicad/app/helm-release.yaml
@@ -82,7 +82,7 @@ spec:
           main:
             image:
               repository: ghcr.io/lenaxia/kicad-desktop
-              tag: 0.1.0
+              tag: "2026.7.11"
               pullPolicy: IfNotPresent
             env:
               TZ: ${TIMEZONE}


### PR DESCRIPTION
## Summary

CI tagged the `kicad-desktop` image as `2026.7.11` (date-based semver from `docker-metadata-action`), not `0.1.0`. The pod is stuck in `ImagePullBackOff` because `ghcr.io/lenaxia/kicad-desktop:0.1.0` doesn't exist.

The `kicad-mcp` image is correctly tagged `0.1.0` (from its `VERSION` variable in `docker-bake.hcl`).

This updates the desktop HelmRelease to use `2026.7.11`.