### PR TITLE
fix(llmsafespaces): expose X-Next-Cursor + X-RateLimit-* in CORS middleware

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/middleware-cors.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/middleware-cors.yaml
@@ -51,5 +51,9 @@ spec:
     accessControlAllowCredentials: true
     accessControlExposeHeaders:
       - X-Request-Id
+      - X-RateLimit-Limit
+      - X-RateLimit-Remaining
+      - X-RateLimit-Reset
+      - X-Next-Cursor
     accessControlMaxAge: 600
     addVaryHeader: true


### PR DESCRIPTION
## Problem

The 'Load earlier messages' button in `chat.safespaces.dev` never renders. The browser calls `GET /api/v1/workspaces/{ws}/sessions/{ses}/message?limit=50` on `api.safespaces.dev`, the response carries `X-Next-Cursor: msg_…` on the wire, but `res.headers.get('X-Next-Cursor')` returns `null` in JS — so `hasNextPage` stays `false` and the button is never shown.

## Root cause

The Traefik Middleware `llmsafespaces-api-cors` (in namespace `llmsafespaces`) had:

```yaml
accessControlExposeHeaders:
  - X-Request-Id
```

Traefik's Headers middleware (`header.go:PostRequestModifyResponseHeaders`) unconditionally calls `res.Header.Set("Access-Control-Expose-Headers", …)` on every actual response when the list is non-empty, **overwriting** whatever the Go app emitted. The app (`api/internal/middleware/security.go:64` in the llmsafespaces repo, present since v0.2.2 / commit `1ca06c51`) correctly emits 5 headers — but Traefik clobbered the value down to 1.

Because the request is cross-origin (`chat.safespaces.dev` → `api.safespaces.dev`), the browser hides any response header not named in `Access-Control-Expose-Headers` from JavaScript. `X-Next-Cursor` and three `X-RateLimit-*` headers were silently stripped from the JS view, even though they were physically on the wire.

## Fix

Add the 4 missing entries to match `DefaultSecurityConfig().ExposedHeaders` in the app:

```yaml
accessControlExposeHeaders:
  - X-Request-Id
  - X-RateLimit-Limit       # new
  - X-RateLimit-Remaining   # new
  - X-RateLimit-Reset       # new
  - X-Next-Cursor           # new
```

## Verification (read-only cluster investigation)

Confirmed end-to-end against prod **before** applying this change:

| Path | `Access-Control-Expose-Headers` |
|---|---|
| Pod-direct (bypass Traefik) | `X-Request-ID, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-Next-Cursor` |
| Traefik-mediated (through ingress) | `X-Request-Id` |

- ✅ Deployed API image: `ghcr.io/lenaxia/llmsafespaces/api:0.3.0` (contains pagination fix)
- ✅ Live Middleware CR matched git state byte-for-byte (no drift — bug is checked in)
- ✅ No competing override: `middlewares-secure-headers` in the chained `networking-chain-no-auth` has no `accessControlExposeHeaders` field
- ✅ Middleware is bound to the `api.safespaces.dev` Ingress via `traefik.ingress.kubernetes.io/router.middlewares` annotation

## Post-deploy verification

After Flux reconciles:

```bash
curl -sI -H 'Origin: https://chat.safespaces.dev' \
  'https://api.safespaces.dev/api/v1/workspaces/<ws>/sessions/<ses>/message?limit=1' \
  | grep -iE 'access-control-expose|x-next-cursor'
```

Expect all 5 headers in `access-control-expose-headers` and `x-next-cursor` visible. Hard-reload `chat.safespaces.dev` — the 'Load earlier messages' button should render.

## Out of scope (filed for follow-up)

1. **`middlewares-secure-headers` (cluster-wide, `networking` ns)** sets `accessControlAllowMethods` without `accessControlAllowOriginList`, which is the reason this bespoke per-app CORS middleware exists at all (per its file comment). Cleaner fix: drop CORS fields from the shared middleware so apps own their CORS — but that's cluster-wide impact, separate PR.

2. **The llmsafespaces chart** documents only the nginx-ingress security-headers path (`frontend-ingress.yaml:14-35`, `values.yaml:1051-1057`, `chart_test.go:3614-3664`) with zero Traefik guidance — which is exactly why this Middleware was hand-rolled and bit-rotted. Separate upstream issue.