### PR TITLE
fix(traefik): remove CORS fields from shared secure-headers middleware

### DIFF
--- a/kubernetes/apps/networking/traefik/middlewares/middlewares.yaml
+++ b/kubernetes/apps/networking/traefik/middlewares/middlewares.yaml
@@ -6,11 +6,13 @@ metadata:
   namespace: networking
 spec:
   headers:
-    accessControlAllowMethods:
-      - GET
-      - OPTIONS
-      - PUT
-    accessControlMaxAge: 100
+    # CORS fields removed (2026-07-20). Setting ANY accessControl* field
+    # activates Traefik's CORS code path, which short-circuits browser
+    # preflight at the edge. Without a matching accessControlAllowOriginList
+    # here, every cross-origin app's preflight failed — that was the root
+    # cause of the bespoke per-app CORS middlewares (e.g. llmsafespaces-api-cors).
+    # Apps that need CORS now own their full config via a dedicated Middleware
+    # bound on their ingress. Apps that don't need CORS are unaffected.
     hostsProxyHeaders:
       - "X-Forwarded-Host"
     stsSeconds: 63072000
@@ -18,16 +20,13 @@ spec:
     stsPreload: true
     frameDeny: true
     forceSTSHeader: true
-    # frameDeny: true #overwritten by customFrameOptionsValue
-    customFrameOptionsValue: "allow-from https:${SECRET_DEV_DOMAIN}" #CSP takes care of this but may be needed for organizr.
     contentTypeNosniff: true
     browserXssFilter: true
-    referrerPolicy: "origin-when-cross-origin"
-      #referrerPolicy: "same-origin"
-    # Setting contentSecurityPolicy is more secure but it can break things. Proper auth will reduce the risk.
-    # the below line also breaks some apps due to 'none' - sonarr, radarr, etc.
-    # contentSecurityPolicy: "frame-ancestors '*.example.com:*';object-src 'none';script-src 'none';"
-    permissionsPolicy: "camera 'none'; geolocation 'none'; microphone 'none'; payment 'none'; usb 'none'; vr 'none';"
+    # strict-origin-when-cross-origin is the modern default (drops the
+    # origin when crossing to a less-secure destination). Pre-fix was
+    # "origin-when-cross-origin" which always leaked the origin.
+    referrerPolicy: "strict-origin-when-cross-origin"
+    permissionsPolicy: "camera=(), geolocation=(), microphone=(), payment=(), usb=(), interest-cohort=()"
     customResponseHeaders:
       X-Robots-Tag: "none,noarchive,nosnippet,notranslate,noimageindex,"
 ---


### PR DESCRIPTION
## Problem

The shared \`middlewares-secure-headers\` Middleware set \`accessControlAllowMethods\` + \`accessControlMaxAge\` **without** \`accessControlAllowOriginList\`. Any \`accessControl*\` field activates Traefik's CORS code path, which short-circuits browser preflight at the edge. Without a matching \`Allow-Origin\` header, every cross-origin app's preflight failed with \`No 'Access-Control-Allow-Origin' header is present\`.

This was the root cause of:
- The bespoke \`llmsafespaces-api-cors\` Middleware ([talos-ops-prod #2053](https://github.com/lenaxia/talos-ops-prod/pull/2053), [LLMSafeSpaces #560](https://github.com/lenaxia/LLMSafeSpaces/pull/560)).
- Likely the same class of issue for other cross-origin apps.

## Fix

**Remove the CORS fields entirely** (\`accessControlAllowMethods\`, \`accessControlMaxAge\`). Apps that need CORS now own their full config via a dedicated Middleware bound on their ingress (llmsafespaces already does this). Apps that don't need CORS are unaffected.

## Security header reconciliation

While removing the CORS fields, also reconciled the security headers with modern best practices:

| Field | Before | After | Why |
|---|---|---|---|
| \`customFrameOptionsValue\` | \`allow-from https:\${SECRET_DEV_DOMAIN}\` | **removed** (uses \`frameDeny: true\` → \`X-Frame-Options: DENY\`) | The cluster-specific value overrode every app's own \`X-Frame-Options\`. Apps like llmsafespaces emit \`DENY\` which is stricter; the old value silently downgraded them. |
| \`referrerPolicy\` | \`origin-when-cross-origin\` | \`strict-origin-when-cross-origin\` | Modern browser default; drops origin when crossing to less-secure destinations. |
| \`permissionsPolicy\` | \`camera 'none'; ...\` (legacy syntax) | \`camera=(), ...\` (W3C syntax) + \`interest-cohort=()\` | W3C parentheses syntax is the current spec; added interest-cohort opt-out for Federated Learning of Cohorts. |

## Backward compatibility

106 apps reference \`chain-no-auth\` / \`chain-authelia\` which expand to include \`middlewares-secure-headers\`. **None relied on the CORS fields for actual CORS behavior** — they had no \`AllowOrigin\`. The header changes make the cluster MORE secure, not less:

- \`frameDeny: true\` (emits \`DENY\`) is stricter than \`allow-from https:thekao.cloud\`.
- \`strict-origin-when-cross-origin\` is stricter than \`origin-when-cross-origin\`.
- W3C \`permissionsPolicy\` syntax is equivalent in enforcement to the legacy form.

Apps that depended on the legacy \`customFrameOptionsValue\` for framing (e.g. organizr dashboards embedding via iframe) will need to set their own \`X-Frame-Options\` via a dedicated Middleware if they want to allow framing. This is a deliberate tradeoff — the cluster-wide default is now the most restrictive value, and exceptions are explicit.

## Related

- [talos-ops-prod #2053](https://github.com/lenaxia/talos-ops-prod/pull/2053) — production CORS fix (llmsafespaces-api-cors expose-headers).
- [LLMSafeSpaces #560](https://github.com/lenaxia/LLMSafeSpaces/pull/560) — operator docs documenting the CORS-at-the-edge pattern.
- [LLMSafeSpaces #567](https://github.com/lenaxia/LLMSafeSpaces/pull/567) — Trivy scan split (unrelated, just merged).