### PR TITLE
chore(llmsafespaces): bump to v0.4.5

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -17,7 +17,7 @@ spec:
         namespace: flux-system
       interval: 15m
       # `reconcileStrategy: Revision` is retained even though the GitRepository
-      # is now pinned to a semver tag (v0.4.4). Rationale: if we ever move a
+      # is now pinned to a semver tag (v0.4.5). Rationale: if we ever move a
       # tag or point at a branch during an emergency rollback, ChartVersion
       # would refuse to re-package (Chart.yaml version wouldn't change). With
       # Revision, source-controller re-packages on every commit SHA change,
@@ -87,7 +87,7 @@ spec:
     # (upstream v0.2.0+) the project cuts real semver releases and CI
     # publishes `<major>.<minor>.<patch>` OCI tags alongside the immutable
     # `ts-<unix>` tags. We pin to the semver — the GitRepository above is
-    # pinned to the matching `tag: v0.4.4`, so the chart-source tree and
+    # pinned to the matching `tag: v0.4.5`, so the chart-source tree and
     # the deployed images roll atomically. To upgrade, bump both the
     # GitRepository ref and every `image.tag` below in the same commit.
     # To verify a semver tag is present on ghcr:
@@ -95,11 +95,11 @@ spec:
     #   curl -sH "Authorization: Bearer $TOKEN" \
     #     -H "Accept: application/vnd.oci.image.index.v1+json" \
     #     -o /dev/null -w "%{http_code}\n" \
-    #     https://ghcr.io/v2/lenaxia/llmsafespaces/api/manifests/0.4.4
+    #     https://ghcr.io/v2/lenaxia/llmsafespaces/api/manifests/0.4.5
     api:
       replicaCount: 2
       image:
-        tag: "0.4.4"
+        tag: "0.4.5"
       config:
         security:
           allowedOrigins:
@@ -110,7 +110,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.4.4"
+        tag: "0.4.5"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -129,7 +129,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.4.4"
+            tag: "0.4.5"
       freeModelsRefresher:
         enabled: false
 
@@ -196,10 +196,10 @@ spec:
       # Pinned to the same semver as api/controller/relay-router/base — the
       # platform rolls atomically because kind/slug wire format, CRD field
       # `workspace.status.userCredsPresent`, and DB migrations must all be
-      # in lockstep. The upstream release-tag build produces `frontend:0.4.4`
+      # in lockstep. The upstream release-tag build produces `frontend:0.4.5`
       # alongside the other four images.
       image:
-        tag: "0.4.4"
+        tag: "0.4.5"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -213,11 +213,11 @@ spec:
     # ── Workspace runtime images ────────────────────────────────────────────
     # The chart seeds a `base` RuntimeEnvironment CR pointing at the base
     # workspace runtime image. Same semver pinning as api/controller/etc —
-    # release-tag builds publish `base:0.4.4` alongside the other four.
+    # release-tag builds publish `base:0.4.5` alongside the other four.
     runtimeEnvironments:
       base:
         image:
-          tag: "0.4.4"
+          tag: "0.4.5"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.4.4
+    tag: v0.4.5
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
Bumps llmsafespaces from v0.4.4 to **v0.4.5**: GitRepository ref + all five image.tag overrides.

## What ships in v0.4.5

- **Kebab menus viewport-aware** (LLMSafeSpaces #583) — menus now flip/clamp/scroll to stay within the viewport; fixes the bottom-most sidebar session's kebab overflowing off-screen.

Release: https://github.com/lenaxia/LLMSafeSpaces/releases/tag/v0.4.5