### PR TITLE
feat(llmsafespaces): bump to v0.5.5

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -17,8 +17,8 @@ spec:
         namespace: flux-system
       interval: 15m
       # `reconcileStrategy: Revision` is retained even though the GitRepository
-      # is now pinned to a semver tag (v0.5.4). Rationale: if we ever move a
-      # is now pinned to a semver tag (v0.5.4). Rationale: if we ever move a
+      # is now pinned to a semver tag (v0.5.5). Rationale: if we ever move a
+      # is now pinned to a semver tag (v0.5.5). Rationale: if we ever move a
       # tag or point at a branch during an emergency rollback, ChartVersion
       # would refuse to re-package (Chart.yaml version wouldn't change). With
       # Revision, source-controller re-packages on every commit SHA change,
@@ -88,8 +88,8 @@ spec:
     # (upstream v0.2.0+) the project cuts real semver releases and CI
     # publishes `<major>.<minor>.<patch>` OCI tags alongside the immutable
     # `ts-<unix>` tags. We pin to the semver — the GitRepository above is
-    # pinned to the matching `tag: v0.5.4`, so the chart-source tree and
-    # pinned to the matching `tag: v0.5.4`, so the chart-source tree and
+    # pinned to the matching `tag: v0.5.5`, so the chart-source tree and
+    # pinned to the matching `tag: v0.5.5`, so the chart-source tree and
     # the deployed images roll atomically. To upgrade, bump both the
     # GitRepository ref and every `image.tag` below in the same commit.
     # To verify a semver tag is present on ghcr:
@@ -98,11 +98,11 @@ spec:
     #     -H "Accept: application/vnd.oci.image.index.v1+json" \
     #     -o /dev/null -w "%{http_code}\n" \
     #     https://ghcr.io/v2/lenaxia/llmsafespaces/api/manifests/0.5.0
-    #     https://ghcr.io/v2/lenaxia/llmsafespaces/api/manifests/0.5.4
+    #     https://ghcr.io/v2/lenaxia/llmsafespaces/api/manifests/0.5.5
     api:
       replicaCount: 2
       image:
-        tag: "0.5.4"
+        tag: "0.5.5"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.5.4"
+        tag: "0.5.5"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -132,7 +132,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.5.4"
+            tag: "0.5.5"
       freeModelsRefresher:
         enabled: false
 
@@ -200,10 +200,10 @@ spec:
       # platform rolls atomically because kind/slug wire format, CRD field
       # `workspace.status.userCredsPresent`, and DB migrations must all be
       # in lockstep. The upstream release-tag build produces `frontend:0.5.0`
-      # in lockstep. The upstream release-tag build produces `frontend:0.5.4`
+      # in lockstep. The upstream release-tag build produces `frontend:0.5.5`
       # alongside the other four images.
       image:
-        tag: "0.5.4"
+        tag: "0.5.5"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -218,11 +218,11 @@ spec:
     # The chart seeds a `base` RuntimeEnvironment CR pointing at the base
     # workspace runtime image. Same semver pinning as api/controller/etc —
     # release-tag builds publish `base:0.5.0` alongside the other four.
-    # release-tag builds publish `base:0.5.4` alongside the other four.
+    # release-tag builds publish `base:0.5.5` alongside the other four.
     runtimeEnvironments:
       base:
         image:
-          tag: "0.5.4"
+          tag: "0.5.5"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.5.4
+    tag: v0.5.5
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
Bumps LLMSafeSpaces from v0.5.4 to **v0.5.5**.

## Release highlights

6 PRs of bug fixes and CI/dependency hygiene:

| PR | Summary |
|---|---|
| [#595](https://github.com/lenaxia/LLMSafeSpaces/pull/595) | Unblock API-key-only admin workspaces (#593) — providersConfigured reporting, actionable DEK error, admin credential cascade |
| [#596](https://github.com/lenaxia/LLMSafeSpaces/pull/596) | Always serialize motd in /auth/config (canary fix) |
| [#597](https://github.com/lenaxia/LLMSafeSpaces/pull/597) | Evict API key cache on delete + postcss CVE bump |
| [#598](https://github.com/lenaxia/LLMSafeSpaces/pull/598) | Sync SDK versions |
| [#599](https://github.com/lenaxia/LLMSafeSpaces/pull/599) | Kind cluster in canary CI + Java/OpenAPI version sync |
| [#600](https://github.com/lenaxia/LLMSafeSpaces/pull/600) | vite 5→8, vitest 2→3, react-router 6→7 + returnTo race fix |

## Changes

- `kubernetes/flux/repositories/git/llmsafespaces.yaml` — GitRepository tag: `v0.5.4` → `v0.5.5`
- `kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml` — all 5 image tags (`api`, `controller`, `relay-router`, `frontend`, `base`) bumped from `0.5.4` → `0.5.5`

## Notes

- No DB migrations in this release (schema unchanged from v0.5.4).
- No CRD schema changes.
- No breaking config changes.
- The upstream release workflow is building images now: https://github.com/lenaxia/LLMSafeSpaces/actions/workflows/release.yml

Full changelog: https://github.com/lenaxia/LLMSafeSpaces/blob/main/CHANGELOG.md#055---2026-07-25