### PR TITLE
feat(llmsafespaces): bump to v0.6.0

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -17,8 +17,8 @@ spec:
         namespace: flux-system
       interval: 15m
       # `reconcileStrategy: Revision` is retained even though the GitRepository
-      # is now pinned to a semver tag (v0.5.5). Rationale: if we ever move a
-      # is now pinned to a semver tag (v0.5.5). Rationale: if we ever move a
+      # is now pinned to a semver tag (v0.6.0). Rationale: if we ever move a
+      # is now pinned to a semver tag (v0.6.0). Rationale: if we ever move a
       # tag or point at a branch during an emergency rollback, ChartVersion
       # would refuse to re-package (Chart.yaml version wouldn't change). With
       # Revision, source-controller re-packages on every commit SHA change,
@@ -88,8 +88,8 @@ spec:
     # (upstream v0.2.0+) the project cuts real semver releases and CI
     # publishes `<major>.<minor>.<patch>` OCI tags alongside the immutable
     # `ts-<unix>` tags. We pin to the semver — the GitRepository above is
-    # pinned to the matching `tag: v0.5.5`, so the chart-source tree and
-    # pinned to the matching `tag: v0.5.5`, so the chart-source tree and
+    # pinned to the matching `tag: v0.6.0`, so the chart-source tree and
+    # pinned to the matching `tag: v0.6.0`, so the chart-source tree and
     # the deployed images roll atomically. To upgrade, bump both the
     # GitRepository ref and every `image.tag` below in the same commit.
     # To verify a semver tag is present on ghcr:
@@ -98,11 +98,11 @@ spec:
     #     -H "Accept: application/vnd.oci.image.index.v1+json" \
     #     -o /dev/null -w "%{http_code}\n" \
     #     https://ghcr.io/v2/lenaxia/llmsafespaces/api/manifests/0.5.0
-    #     https://ghcr.io/v2/lenaxia/llmsafespaces/api/manifests/0.5.5
+    #     https://ghcr.io/v2/lenaxia/llmsafespaces/api/manifests/0.6.0
     api:
       replicaCount: 2
       image:
-        tag: "0.5.5"
+        tag: "0.6.0"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.5.5"
+        tag: "0.6.0"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -132,7 +132,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.5.5"
+            tag: "0.6.0"
       freeModelsRefresher:
         enabled: false
 
@@ -200,10 +200,10 @@ spec:
       # platform rolls atomically because kind/slug wire format, CRD field
       # `workspace.status.userCredsPresent`, and DB migrations must all be
       # in lockstep. The upstream release-tag build produces `frontend:0.5.0`
-      # in lockstep. The upstream release-tag build produces `frontend:0.5.5`
+      # in lockstep. The upstream release-tag build produces `frontend:0.6.0`
       # alongside the other four images.
       image:
-        tag: "0.5.5"
+        tag: "0.6.0"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -218,11 +218,11 @@ spec:
     # The chart seeds a `base` RuntimeEnvironment CR pointing at the base
     # workspace runtime image. Same semver pinning as api/controller/etc —
     # release-tag builds publish `base:0.5.0` alongside the other four.
-    # release-tag builds publish `base:0.5.5` alongside the other four.
+    # release-tag builds publish `base:0.6.0` alongside the other four.
     runtimeEnvironments:
       base:
         image:
-          tag: "0.5.5"
+          tag: "0.6.0"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.5.5
+    tag: v0.6.0
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
## Summary

Bumps LLMSafeSpaces from v0.5.5 to v0.6.0. Ships two upstream PRs:

- **#602** — `fix(helm): remember-me 30d TTL + feat: instance-default /tmp/* auto-approval`
  - Chart now renders `rememberMeDuration: 720h` (was silently 24h in Helm deploys)
  - New instance setting `workspace.allowedExternalDirectories` (default `["/tmp/*"]`) auto-approves `/tmp` as an opencode external_directory allow-rule

- **#603** — `fix(api,canary): workspace CRUD canary failures`
  - API-layer storage validation (format + 1024Gi max cap)
  - `GetWorkspace` returns 404 after deletion (was returning ghost row with empty phase)
  - SDK `BindingItem.ID` JSON tag fix + `CreateWithMetadata` method
  - 10+ canary assertion fixes

## Changes

- GitRepository tag: `v0.5.5` → `v0.6.0`
- All 5 image tags (api, controller, relay-router, frontend, base): `0.5.5` → `0.6.0`