### PR TITLE
feat(opengist): add opengist-mcp server

### DIFF
--- a/kubernetes/apps/home/opengist/ks.yaml
+++ b/kubernetes/apps/home/opengist/ks.yaml
@@ -23,3 +23,32 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+---
+# opengist-mcp — MCP server sidecar (separate Kustomization so it can be
+# debugged/reverted independently of the opengist pod).
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-home-opengist-mcp
+  namespace: flux-system
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  dependsOn:
+    # The MCP server calls the Opengist REST API; the opengist app must be
+    # reconciled and healthy first.
+    - name: cluster-home-opengist
+  path: ./kubernetes/apps/home/opengist/mcp/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: opengist-mcp
+      namespace: home
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/home/opengist/mcp/app/configmap.yaml
+++ b/kubernetes/apps/home/opengist/mcp/app/configmap.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: opengist-mcp
+    namespace: home
+data:
+    # Opengist API token (og_...) for the service account the MCP server
+    # authenticates as. Generate one in Opengist under
+    #   User Settings -> Access Tokens
+    #
+    # NOTE: This is a ConfigMap placeholder so the manifest can be committed
+    # before a token exists. A real token is a credential — when you fill
+    # this in, convert it back to a SOPS-encrypted Secret (see
+    # README-LLM.md "CRITICAL RULES") and flip envFrom back to secretRef.
+    OPENGIST_TOKEN: PLACEHOLDER

--- a/kubernetes/apps/home/opengist/mcp/app/helm-release.yaml
+++ b/kubernetes/apps/home/opengist/mcp/app/helm-release.yaml
@@ -1,0 +1,139 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-4.6.2/charts/other/app-template/values.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app opengist-mcp
+  namespace: home
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 4
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 4
+  uninstall:
+    keepHistory: false
+  values:
+    # ──────────────────────────────────────────────────────────────────────
+    # opengist-mcp — MCP server bridging LLM agents to Opengist
+    # ──────────────────────────────────────────────────────────────────────
+    # Architecture mirrors hass-mcp / kicad-mcp in this cluster:
+    #   supergateway (Node, HTTP/SSE on :8000)
+    #     └── stdio child: python3 -m opengist_mcp
+    #
+    # The ghcr.io/lenaxia/opengist-mcp image bundles supergateway and sets
+    # the stdio/port/healthEndpoint CMD, so no command/args override is
+    # needed.
+    #
+    # Network exposure: ClusterIP only. Reachable as
+    #   http://opengist-mcp.home.svc.cluster.local:8000/sse
+    # Security note: supergateway has no inbound auth (verified via --help).
+    # In-cluster access is the only protection. LiteLLM consumes this and
+    # is the documented client; LiteLLM itself is Authelia-protected.
+    # ──────────────────────────────────────────────────────────────────────
+    defaultPodOptions:
+      nodeSelector:
+        node-role.kubernetes.io/worker: "true"
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      main:
+        type: deployment
+        replicas: 1
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            image:
+              repository: ghcr.io/lenaxia/opengist-mcp
+              tag: "0.1.0"
+              pullPolicy: IfNotPresent
+            env:
+              # Base URL of the in-cluster Opengist instance (REST API).
+              OPENGIST_URL: http://opengist.home.svc.cluster.local:6157
+              # HTTP timeout (seconds). Documented default is 30.
+              OPENGIST_TIMEOUT: "30"
+              # Writable HOME for any process cache/state.
+              HOME: /home/app
+              TZ: ${TIMEZONE}
+            envFrom:
+              - configMapRef:
+                  name: opengist-mcp
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8000
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  failureThreshold: 5
+                  timeoutSeconds: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8000
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  failureThreshold: 30
+                  timeoutSeconds: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8000
+                  periodSeconds: 10
+                  failureThreshold: 30
+                  timeoutSeconds: 5
+    persistence:
+      # Writable HOME (image sets HOME=/home/app). Rebuilt on pod start.
+      home:
+        type: emptyDir
+        sizeLimit: 1Gi
+        globalMounts:
+          - path: /home/app
+      # supergateway writes session/transient state under /tmp.
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    service:
+      main:
+        primary: true
+        controller: main
+        type: ClusterIP
+        ports:
+          http:
+            port: 8000
+            targetPort: 8000
+            protocol: TCP

--- a/kubernetes/apps/home/opengist/mcp/app/kustomization.yaml
+++ b/kubernetes/apps/home/opengist/mcp/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helm-release.yaml
+  - ./configmap.yaml


### PR DESCRIPTION
## Summary

Adds the [opengist-mcp](https://github.com/lenaxia/containers/tree/main/apps/opengist-mcp) MCP server alongside the existing Opengist deployment, so LLM agents (via LiteLLM) can manage gists programmatically.

## Changes

- **`kubernetes/apps/home/opengist/mcp/app/helm-release.yaml`** — Deployment of `ghcr.io/lenaxia/opengist-mcp:0.1.0` via `app-template`. The image bundles supergateway (HTTP/SSE on `:8000`) wrapping a stdio `python3 -m opengist_mcp` child. ClusterIP-only, `/healthz` liveness/readiness/startup probes, UID 568, emptyDirs for `/home/app` + `/tmp`. Points at the in-cluster Opengist API: `OPENGIST_URL=http://opengist.home.svc.cluster.local:6157`.
- **`kubernetes/apps/home/opengist/mcp/app/configmap.yaml`** — ConfigMap with `OPENGIST_TOKEN: PLACEHOLDER`.
- **`kubernetes/apps/home/opengist/mcp/app/kustomization.yaml`** — references the above.
- **`kubernetes/apps/home/opengist/ks.yaml`** — appends a second Flux `Kustomization` (`cluster-home-opengist-mcp`, `dependsOn: cluster-home-opengist`).

## Design notes

- Mirrors the existing MCP pattern in this namespace (`hass-mcp`, `kicad/mcp`, `hortusfox-mcp`) — supergateway + ClusterIP, no ingress, LiteLLM is the intended client.
- Separate Flux `Kustomization` so the MCP pod can be debugged/reverted independently of the opengist app, same approach as `kicad`.

## ⚠️ Follow-up required

`OPENGIST_TOKEN` is committed as a ConfigMap placeholder. A real API token is a credential. After merge:
1. Generate an Opengist token (`og_...`) for a dedicated service account.
2. Replace `configmap.yaml` with a SOPS-encrypted `secret.sops.yaml`.
3. Flip `envFrom` from `configMapRef` back to `secretRef`.

Until then the pod runs in anonymous mode (public gists only).

## Notes
- Image is amd64-only (consistent with the other lenaxia MCP images).
- No new HelmRepository needed — reuses `bjw-s` `app-template` 5.0.1.