### PR TITLE
fix(vector): resolve 0.57.0 template confinement breaking change

### DIFF
--- a/kubernetes/apps/monitoring/vector/aggregator/config/vector.yaml
+++ b/kubernetes/apps/monitoring/vector/aggregator/config/vector.yaml
@@ -89,6 +89,13 @@ sinks:
     out_of_order_action: accept
     remove_label_fields: true
     remove_timestamp: true
+    # Vector 0.57.0 enforces template confinement on {{ }} sink templates
+    # and rejects label templates with no literal prefix at startup. These are
+    # low-cardinality, operator-controlled Loki labels (host/custom_app_name/
+    # namespace/node), so opt out to preserve pre-0.57 label values verbatim.
+    # Prefixing the values (e.g. 'host-{{ host }}') would corrupt label values
+    # and break existing Grafana queries/dashboards/alerts.
+    dangerously_allow_unconfined_template_resolution: true
   kubernetes:
     type: loki
     batch:
@@ -105,6 +112,7 @@ sinks:
     out_of_order_action: accept
     remove_label_fields: true
     remove_timestamp: true
+    dangerously_allow_unconfined_template_resolution: true
 #  opnsense:
 #    type: loki
 #    batch:


### PR DESCRIPTION
## Summary

Vector **0.57.0** (shipped to `main` via #2043) is a security-focused release with two breaking changes. This PR applies the one that actually affects this cluster's config.

### What broke

**Template confinement** — sinks now enforce a confinement boundary on `{{ field }}` routing templates and **reject templates with no literal prefix at startup**. Both Loki sinks in the aggregator use unprefixed templates:

```yaml
labels:
  hostname: '{{ host }}'
  app: '{{ custom_app_name }}'
  namespace: '{{ kubernetes.pod_namespace }}'
  node: '{{ kubernetes.pod_node_name }}'
```

Without a fix the aggregator fails to start. Source: [0.57.0 release notes](https://vector.dev/releases/0.57.0/).

### The fix

Add `dangerously_allow_unconfined_template_resolution: true` at **sink level** (4-space indent) on both Loki sinks (`journald` + `kubernetes`). These are low-cardinality, operator-controlled labels — the documented opt-out fully restores pre-0.57 behavior (including label *values*) and is the right choice here.

The **agent** (DaemonSet) needs no change: its sinks are `type: vector` with no `{{ }}` templates.

### Why not the other two breaking-change PRs

| PR | Approach | Problem |
|---|---|---|
| **#2057** | Prefix all label values (`host-{{ host }}`, `app-{{ ... }}`) + add `VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION` | Prefixing **corrupts Loki label values** → breaks Grafana dashboards/queries/alerts. The env var is unnecessary: no active `${VAR}` interpolation exists (only a commented-out `externalIPs` line). |
| **#2055** | Correct option (`dangerously_allow_unconfined_template_resolution`) | **Indentation bug**: nests it (and `out_of_order_action`/`remove_label_fields`/`remove_timestamp`) *under* `labels:` instead of at sink level → misparsed config. |

This PR supersedes both.

### Checklist
- [x] Image already at `0.57.0-debian` on main (via #2043)
- [x] No `${VAR}` interpolation in active config → no env var needed
- [x] Aggregator: confinement opt-out on both Loki sinks
- [x] Agent: no change needed
- [x] Label values preserved verbatim (no dashboard breakage)