### PR TITLE
fix(longhorn): prevent Flux upgrade loop (timeout + disableHooks + reduced retries)

### DIFF
--- a/kubernetes/apps/storage/longhorn/app/helm-release.yaml
+++ b/kubernetes/apps/storage/longhorn/app/helm-release.yaml
@@ -14,12 +14,27 @@ spec:
         name: longhorn
         namespace: flux-system
   interval: 6m
+  # Longhorn upgrades involve data migrations and slow CSI component rollouts.
+  # Use a 15-minute timeout to accommodate:
+  #   - Engine image upgrades across all nodes
+  #   - CSI DaemonSet foreground deletion + recreation
+  # Without this, Flux times out at 5m and triggers rollbacks.
+  timeout: 15m
   install:
     remediation:
-      retries: 7
+      retries: 3
   upgrade:
+    # disableHooks: bypass the pre-upgrade Job hook.
+    # Longhorn's longhorn-pre-upgrade Job has hook-delete-policy: hook-succeeded
+    # which deletes the Job immediately on success. Helm 4's hook wait loop then
+    # sees Job status: NotFound and treats it as a failure — even though the Job
+    # succeeded. This is a Helm 4 regression (https://github.com/helm/helm/issues/XXXX).
+    # The pre-upgrade job only validates the upgrade path is supported; we accept
+    # the (very small) risk of skipping it given Renovate controls the version bump.
+    disableHooks: true
     remediation:
-      retries: 7
+      retries: 3
+      remediateLastFailure: true
   #valuesFrom:
   #  - kind: Secret
   #    targetPath: defaultSettings.backupTarget


### PR DESCRIPTION
Extracted from #1825 (longhorn-only commit). The LiteLLM model-config changes in #1825 are unrelated to the upgrade-loop fix and are left out of this PR for separate review.

## Problem

Longhorn HelmRelease upgrades wedge in an endless Flux install/remediation loop on `main` today (config still has `retries: 7`, default 5m timeout, hooks enabled). Two causes:

1. **Timeout too short** — Longhorn upgrades run engine-image migrations across all nodes and foreground CSI DaemonSet delete+recreate. Flux's default 5m timeout fires mid-rollout and triggers a rollback.
2. **Helm 4 hook regression** — Longhorn's `longhorn-pre-upgrade` Job uses `hook-delete-policy: hook-succeeded`, so it's deleted immediately on success. Helm 4's hook-wait loop then sees `Job NotFound` and treats a **succeeded** hook as a failure, driving the release into remediation.

## Fix

```yaml
interval: 6m
timeout: 15m                       # accommodate migrations + CSI rollout
install:
  remediation:
    retries: 3                     # was 7 — limits remediation-loop blast radius
upgrade:
  disableHooks: true               # bypass the pre-upgrade Job (Helm 4 regression)
  remediation:
    retries: 3                     # was 7
    remediateLastFailure: true
```

### Note on `disableHooks: true`
This skips Longhorn's pre-upgrade validation Job, which only checks the upgrade path is supported. With Renovate controlling single-step version bumps, skipping it is low-risk — but it IS an operational tradeoff. Kept as the original author intended in #1825.

This is an upgrade-safety fix; the unrelated LiteLLM changes from #1825 are deferred.