### PR TITLE
fix(prometheus): switch TSDB PVC to longhorn for node-failure portability

### DIFF
--- a/kubernetes/apps/monitoring/prometheus-stack/app/helm-release.yaml
+++ b/kubernetes/apps/monitoring/prometheus-stack/app/helm-release.yaml
@@ -248,7 +248,7 @@ spec:
         storageSpec:
           volumeClaimTemplate:
             spec:
-              storageClassName: openebs-hostpath
+              storageClassName: longhorn
               accessModes: ["ReadWriteOnce"]
               resources:
                 requests:


### PR DESCRIPTION
Replaces #1835 with the fix that addresses the actual root cause.

## Root cause (#1835 misdiagnosis)

The original issue: `PVC stuck on unavailable node worker-02`.

#1835 proposed adding a `node-role.kubernetes.io/control-plane` toleration, but that doesn't fix a node-bound PVC and would land monitoring on etcd nodes (anti-pattern). The real cause is the **storage class**:

```yaml
storageSpec:
  volumeClaimTemplate:
    spec:
      storageClassName: openebs-hostpath   # ← node-local, non-portable
```

`openebs-hostpath` writes to a single node's local disk. The PVC is permanently pinned to that node — when the node goes down, the pod can't reschedule because no other node can mount that volume.

## Fix

```yaml
storageClassName: longhorn   # was openebs-hostpath
```

Longhorn is the cluster default and 3-way replicated across nodes. The volume is portable — if a node fails, Longhorn rebuilds from replicas and the pod reattaches to a healthy node automatically.

## Data migration note

Changing `storageClassName` creates a **new** PVC; the operator won't auto-migrate the existing openebs-hostpath data. With `replicas: 3` all scraping the same targets, there's no query gap — the replica simply re-ingests fresh. To apply cleanly:

1. Merge this PR.
2. Manually delete the old `openebs-hostpath` PVCs (`prometheus-\<stack\>-prometheus-0/1/2-db-`) once the new longhorn PVCs are bound — the old ones are orphaned after the switch.

Alternatively, do the PVC cutover during a maintenance window if you want to preserve local historical data (would require a manual copy). For a monitoring stack, fresh re-ingest is normally fine.

## Checklist
- [x] Fixes the actual root cause (non-portable storage)
- [x] No control-plane toleration (keeps monitoring off etcd nodes)
- [x] Consistent with cluster default storage policy (longhorn)
- [x] `replicas: 3` provides query redundancy during cutover

Supersedes and closes #1835.