### PR TITLE
fix(prometheus): hostpath storage + pvc-reaper for self-recovery on node loss

### DIFF
--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./namespace.yaml
   - ./flux
   - ./prometheus-stack/ks.yaml
+  - ./pvc-reaper/ks.yaml
   - ./grafana/ks.yaml
   #- ./loki/ks.yaml
   #- ./vector/ks.yaml

--- a/kubernetes/apps/monitoring/prometheus-stack/app/helm-release.yaml
+++ b/kubernetes/apps/monitoring/prometheus-stack/app/helm-release.yaml
@@ -245,10 +245,20 @@ spec:
         walCompression: true
         enableFeatures:
           - memory-snapshot-on-shutdown
+        # Data redundancy comes from prometheusSpec.replicas: 3 (each replica
+        # scrapes and stores a full copy), so node-local storage is fine and
+        # avoids Longhorn's write amplification on a write-heavy TSDB.
+        # On node loss the stuck PVC must be deleted so the StatefulSet replica
+        # can reschedule onto a healthy node and re-ingest — handled by the
+        # pvc-reaper CronJob in this namespace. The retention policy below
+        # ensures PVCs are also reclaimed on Prometheus CR deletion / scale-down.
+        persistentVolumeClaimRetentionPolicy:
+          whenDeleted: Delete
+          whenScaled: Retain
         storageSpec:
           volumeClaimTemplate:
             spec:
-              storageClassName: longhorn
+              storageClassName: openebs-hostpath
               accessModes: ["ReadWriteOnce"]
               resources:
                 requests:

--- a/kubernetes/apps/monitoring/pvc-reaper/app/cronjob.yaml
+++ b/kubernetes/apps/monitoring/pvc-reaper/app/cronjob.yaml
@@ -1,0 +1,79 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone/cronjob-batch-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pvc-reaper
+  namespace: monitoring
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          serviceAccountName: pvc-reaper
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+          containers:
+            - name: reaper
+              # kubectl + jq + yq, same minor as the cluster (1.36.x).
+              image: alpine/k8s:1.36.2
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: NAMESPACES
+                  value: monitoring
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  NS="${NAMESPACES:-monitoring}"
+
+                  # Nodes that are NOT Ready (covers Ready=False, Unknown, and
+                  # missing condition). These are the hosts whose local PVCs
+                  # can never be reattached and must be reaped.
+                  NOTREADY="$(kubectl get nodes -o json \
+                    | jq -r '[.items[]
+                        | select(((.status.conditions // [])
+                                  | map(select(.type=="Ready" and .status=="True"))
+                                  | length) == 0)
+                        | .metadata.name] | .[]')"
+
+                  if [ -z "$NOTREADY" ]; then
+                    echo "all nodes Ready; nothing to do"
+                    exit 0
+                  fi
+
+                  echo "not-ready nodes:"; echo "$NOTREADY"
+                  reaped=0
+
+                  for ns in $NS; do
+                    for pvc in $(kubectl -n "$ns" get pvc -o name 2>/dev/null); do
+                      pv="$(kubectl -n "$ns" get "$pvc" -o jsonpath='{.spec.volumeName}')"
+                      [ -z "$pv" ] && continue
+
+                      # Resolve the node a local PV (openebs-hostpath etc.) is
+                      # pinned to via its nodeAffinity. Networked PVs have no
+                      # such affinity and are skipped.
+                      node="$(kubectl get pv "$pv" -o json 2>/dev/null \
+                        | jq -r '.spec.nodeAffinity.required.nodeSelectorTerms[]?
+                                 .matchExpressions[]?
+                                 | select(.key=="kubernetes.io/hostname")
+                                 | .values[0]' 2>/dev/null | head -n1 || true)"
+                      [ -z "$node" ] && continue
+
+                      if echo "$NOTREADY" | grep -qFx "$node"; then
+                        echo "reaping $pvc in ns/$ns (pv=$pv pinned to not-ready node=$node)"
+                        kubectl -n "$ns" delete "$pvc" --ignore-not-found >/dev/null \
+                          && reaped=$((reaped+1))
+                      fi
+                    done
+                  done
+
+                  echo "done. reaped $reaped pvc(s)."

--- a/kubernetes/apps/monitoring/pvc-reaper/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/pvc-reaper/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./serviceaccount.yaml
+  - ./rbac.yaml
+  - ./cronjob.yaml

--- a/kubernetes/apps/monitoring/pvc-reaper/app/rbac.yaml
+++ b/kubernetes/apps/monitoring/pvc-reaper/app/rbac.yaml
@@ -1,0 +1,52 @@
+---
+# Cluster-scoped read access: nodes (to detect NotReady) and persistentvolumes
+# (to resolve a PVC's bound node via PV nodeAffinity).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pvc-reaper
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pvc-reaper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pvc-reaper
+subjects:
+  - kind: ServiceAccount
+    name: pvc-reaper
+    namespace: monitoring
+---
+# Namespaced: delete PVCs only within the monitoring namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pvc-reaper
+  namespace: monitoring
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pvc-reaper
+  namespace: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pvc-reaper
+subjects:
+  - kind: ServiceAccount
+    name: pvc-reaper
+    namespace: monitoring

--- a/kubernetes/apps/monitoring/pvc-reaper/app/serviceaccount.yaml
+++ b/kubernetes/apps/monitoring/pvc-reaper/app/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pvc-reaper
+  namespace: monitoring

--- a/kubernetes/apps/monitoring/pvc-reaper/ks.yaml
+++ b/kubernetes/apps/monitoring/pvc-reaper/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-monitoring-pvc-reaper
+  namespace: flux-system
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: pvc-reaper
+  path: ./kubernetes/apps/monitoring/pvc-reaper/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Replaces #2108. Implements the desired behavior: **zero write amplification + self-recovery on node loss**.

## Why not #2108 (longhorn)

`replicas: 3` already gives Prometheus app-level data redundancy — each replica scrapes and stores a full, independent copy. Longhorn replication on top is pure 2–3x write amplification on a write-heavy TSDB for no extra safety. `openebs-hostpath` (node-local, fast) is the right backend; the only problem is what happens when a node dies.

## The node-loss problem

When worker-02 went down (#1835), the hostpath PVC stayed pinned to that node and the StatefulSet replica could never reschedule — that's the real failure. `persistentVolumeClaimRetentionPolicy` does NOT fix this (it only fires on StatefulSet delete/scale-down, never on node loss). Nothing in native k8s auto-deletes a stuck local PVC on node death.

## Fix: pvc-reaper CronJob

New `pvc-reaper` CronJob in the monitoring namespace, runs every 10 minutes:
1. Lists NotReady nodes (Ready != True).
2. For each monitoring PVC, resolves its bound PV's `nodeAffinity` node.
3. Deletes the PVC if that node is NotReady.

The StatefulSet controller then provisions a fresh PVC on a healthy node and the replica re-ingests from scratch. **Nothing is lost** — the other 2 replicas retain all metrics, and a fresh re-ingest catches up. Networked PVs (no nodeAffinity) are skipped, so only node-local volumes are ever reaped.

### RBAC (least privilege)
- Cluster: `nodes` + `persistentvolumes` **read** only.
- Namespace `monitoring`: `persistentvolumeclaims` get/list/**delete**.
- PVC deletion is scoped to monitoring only.

## Also: PVC retention policy

```yaml
persistentVolumeClaimRetentionPolicy:
  whenDeleted: Delete
  whenScaled: Retain
```
So PVCs are also reclaimed on Prometheus CR deletion (covers operator-driven churn).

## Image
`alpine/k8s:1.36.2` — bundles kubectl + jq, same minor as the cluster (1.36.3). Pinned (no floating tag).

## Note
This reverts the `storageClassName: longhorn` from #2108 back to `openebs-hostpath`.