### PR TITLE
feat(kube-system): add nvidia-power-limit DaemonSet

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -16,4 +16,5 @@ resources:
   - ./node-feature-discovery/ks.yaml
     #- ./nvidia-gpu-operator/ks.yaml
   - ./nvidia-device-plugin/ks.yaml
+  - ./nvidia-power-limit/ks.yaml
   - ./multus/ks.yaml

--- a/kubernetes/apps/kube-system/nvidia-power-limit/app/helm-release.yaml
+++ b/kubernetes/apps/kube-system/nvidia-power-limit/app/helm-release.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/values.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nvidia-power-limit
+  namespace: kube-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+    controllers:
+      main:
+        type: daemonset
+        strategy: RollingUpdate
+        containers:
+          main:
+            image:
+              repository: nvidia/cuda
+              tag: 12.4.1-runtime-ubuntu22.04
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                set -eu
+                echo "[$(date)] nvidia-power-limit daemon starting"
+                nvidia-smi -pm 1
+                while true; do
+                  for i in $$(nvidia-smi --query-gpu=index --format=csv,noheader); do
+                    GPU_NAME=$$(nvidia-smi --query-gpu=name --format=csv,noheader -i $$i | tr -d '\r')
+                    case "$$GPU_NAME" in
+                      *"RTX 3090"*) POWER_LIMIT=275 ;;
+                      *"RTX 4090"*) POWER_LIMIT=325 ;;
+                      *) POWER_LIMIT=250 ;;
+                    esac
+                    CURRENT=$$(nvidia-smi --query-gpu=power.limit --format=csv,noheader,nounits -i $$i | tr -d '\r')
+                    if [ "$$CURRENT" != "$$POWER_LIMIT" ]; then
+                      if nvidia-smi -i $$i -pl $$POWER_LIMIT; then
+                        echo "[$(date)] GPU $$i ($$GPU_NAME): $${CURRENT}W -> $${POWER_LIMIT}W"
+                      else
+                        echo "[$(date)] GPU $$i ($$GPU_NAME): FAILED to set $${POWER_LIMIT}W"
+                      fi
+                    fi
+                  done
+                  sleep 300
+                done
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi
+            securityContext:
+              privileged: true
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false

--- a/kubernetes/apps/kube-system/nvidia-power-limit/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/nvidia-power-limit/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - ./helm-release.yaml

--- a/kubernetes/apps/kube-system/nvidia-power-limit/ks.yaml
+++ b/kubernetes/apps/kube-system/nvidia-power-limit/ks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=http://kubernetes-schemas.local.lan:8080/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-nvidia-power-limit
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-nvidia-device-plugin
+  path: ./kubernetes/apps/kube-system/nvidia-power-limit/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m


### PR DESCRIPTION
## Summary

- Adds a privileged **DaemonSet** (`nvidia-power-limit`) that enforces per-GPU-model power limits on every GPU node, **regardless of what workloads are running**.
- Supersedes the commented-out per-pod initContainer in `tabbyapi/helm-release.yaml`, which only capped the GPU for that single pod at startup.

### Why a DaemonSet (not an admission webhook / initContainer)

| Requirement | DaemonSet | Webhook/initContainer |
|---|---|---|
| Caps GPU when **no** workload is running | ✅ | ❌ |
| Survives workload churn/termination | ✅ | ❌ |
| Defends against mid-run resets | ✅ (re-applies every 5 min) | ❌ (runs once) |
| Shared time-sliced GPUs | ✅ (one cap per board) | ❌ (N containers fighting) |

### Behavior

- **Schedules on GPU nodes only** via `nodeSelector: nvidia.com/gpu.present: "true"` (label set by GPU Feature Discovery).
- **Per-GPU-model limits**:
  - RTX 3090 → 275W
  - RTX 4090 → 325W
  - Fallback → 250W
- **Handles multiple GPUs per node** — iterates every GPU index and queries the model name per-index.
- **Idempotent** — queries the current power limit first and only calls `nvidia-smi -pl` when the value differs from target. At steady state the daemon is silent and makes zero write calls.
- **Does not request `nvidia.com/gpu` resources** — does not consume any GPU allocation slots, so no scheduling conflict with vLLM, tabbyapi, Jellyfin transcode, etc.
- Re-checks every 5 minutes to survive resets from node events or workloads.

### Files

```
kubernetes/apps/kube-system/nvidia-power-limit/
    ks.yaml                      Flux Kustomization (dependsOn nvidia-device-plugin)
    app/
        kustomization.yaml
        helm-release.yaml        app-template 5.0.1 DaemonSet
```

Registered in `kubernetes/apps/kube-system/kustomization.yaml`.