### PR TITLE
fix(nvidia-power-limit): use NFD PCI label so all GPU nodes are matched

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-power-limit/app/helm-release.yaml
+++ b/kubernetes/apps/kube-system/nvidia-power-limit/app/helm-release.yaml
@@ -28,7 +28,7 @@ spec:
   values:
     defaultPodOptions:
       nodeSelector:
-        nvidia.com/gpu.present: "true"
+        feature.node.kubernetes.io/pci-10de.present: "true"
     controllers:
       main:
         type: daemonset


### PR DESCRIPTION
## Summary

Fixes the DaemonSet not scheduling on `worker-04` (RTX 4090).

**Root cause:** The nodeSelector `nvidia.com/gpu.present: "true"` is only set by the NVIDIA GPU Operator. worker-00 has stale labels from a prior GPU Operator deployment (now commented out in `kustomization.yaml:17`). worker-04 was added later with only the standalone `nvidia-device-plugin` + GFD, which does **not** set that label.

**Fix:** Switch to `feature.node.kubernetes.io/pci-10de.present: "true"` — set by Node Feature Discovery on any node with an NVIDIA PCI device (vendor ID `10de`). Verified present on both `worker-00` and `worker-04`.

One-line change.