### PR TITLE
bump(llmsafespaces): v0.7.0 — MCP Server Integration

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -17,8 +17,8 @@ spec:
         namespace: flux-system
       interval: 15m
       # `reconcileStrategy: Revision` is retained even though the GitRepository
-      # is now pinned to a semver tag (v0.6.0). Rationale: if we ever move a
-      # is now pinned to a semver tag (v0.6.0). Rationale: if we ever move a
+      # is now pinned to a semver tag (v0.7.0). Rationale: if we ever move a
+      # is now pinned to a semver tag (v0.7.0). Rationale: if we ever move a
       # tag or point at a branch during an emergency rollback, ChartVersion
       # would refuse to re-package (Chart.yaml version wouldn't change). With
       # Revision, source-controller re-packages on every commit SHA change,
@@ -88,8 +88,8 @@ spec:
     # (upstream v0.2.0+) the project cuts real semver releases and CI
     # publishes `<major>.<minor>.<patch>` OCI tags alongside the immutable
     # `ts-<unix>` tags. We pin to the semver — the GitRepository above is
-    # pinned to the matching `tag: v0.6.0`, so the chart-source tree and
-    # pinned to the matching `tag: v0.6.0`, so the chart-source tree and
+    # pinned to the matching `tag: v0.7.0`, so the chart-source tree and
+    # pinned to the matching `tag: v0.7.0`, so the chart-source tree and
     # the deployed images roll atomically. To upgrade, bump both the
     # GitRepository ref and every `image.tag` below in the same commit.
     # To verify a semver tag is present on ghcr:
@@ -98,11 +98,11 @@ spec:
     #     -H "Accept: application/vnd.oci.image.index.v1+json" \
     #     -o /dev/null -w "%{http_code}\n" \
     #     https://ghcr.io/v2/lenaxia/llmsafespaces/api/manifests/0.5.0
-    #     https://ghcr.io/v2/lenaxia/llmsafespaces/api/manifests/0.6.0
+    #     https://ghcr.io/v2/lenaxia/llmsafespaces/api/manifests/0.7.0
     api:
       replicaCount: 2
       image:
-        tag: "0.6.0"
+        tag: "0.7.0"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.6.0"
+        tag: "0.7.0"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -132,7 +132,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.6.0"
+            tag: "0.7.0"
       freeModelsRefresher:
         enabled: false
 
@@ -200,10 +200,10 @@ spec:
       # platform rolls atomically because kind/slug wire format, CRD field
       # `workspace.status.userCredsPresent`, and DB migrations must all be
       # in lockstep. The upstream release-tag build produces `frontend:0.5.0`
-      # in lockstep. The upstream release-tag build produces `frontend:0.6.0`
+      # in lockstep. The upstream release-tag build produces `frontend:0.7.0`
       # alongside the other four images.
       image:
-        tag: "0.6.0"
+        tag: "0.7.0"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -218,11 +218,11 @@ spec:
     # The chart seeds a `base` RuntimeEnvironment CR pointing at the base
     # workspace runtime image. Same semver pinning as api/controller/etc —
     # release-tag builds publish `base:0.5.0` alongside the other four.
-    # release-tag builds publish `base:0.6.0` alongside the other four.
+    # release-tag builds publish `base:0.7.0` alongside the other four.
     runtimeEnvironments:
       base:
         image:
-          tag: "0.6.0"
+          tag: "0.7.0"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.6.0
+    tag: v0.7.0
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
## Summary

Bumps LLMSafeSpaces from v0.6.0 → v0.7.0.

### What shipped ([CHANGELOG](https://github.com/lenaxia/LLMSafeSpaces/blob/main/CHANGELOG.md#070---2026-08-02))

**MCP Server Integration (Epic 53)** — platform/org/user-scoped external MCP servers with three transports (http, sse, stdio), encrypted at rest, injected into workspace pods, and governed by org policies + plan-tier quotas + a platform kill-switch.

Also fixes: passkey login redirect, passkey e2e cookie auth.

### Changes

- `kubernetes/flux/repositories/git/llmsafespaces.yaml`: `tag: v0.6.0` → `v0.7.0`
- `kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml`: all 5 image tags `0.6.0` → `0.7.0`

### Migration

Migration `000012` (mcp_servers, mcp_server_bindings, mcp_server_auto_apply) runs automatically via the chart's pre-upgrade Helm hook. Settings schema bumped to v8 (adds `mcp.allowOrgAdminServers`).

🤖 Generated with [opencode](https://opencode.ai)