### PR TITLE
feat(authelia): add llmsafespaces OIDC client for org-level SSO

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -261,8 +261,8 @@ spec:
     # Authelia is registered as the IdP for the "thekaocloud" org — see the
     # llmsafespaces OIDC client in networking/authelia/app/helm-release.yaml.
     oidc:
-      redirectBaseUrl: "https://api.safespaces.dev"
-      frontendRedirectUrl: "https://chat.safespaces.dev"
+      redirectBaseUrl: "https://api.${SECRET_SAFESPACES_DOMAIN}"
+      frontendRedirectUrl: "https://chat.${SECRET_SAFESPACES_DOMAIN}"
 
     # ── Subdomain routing ───────────────────────────────────────────────────
     # Disabled — single-host frontend per design call. If we ever want

--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -252,6 +252,18 @@ spec:
     # router-only stage — no fleet provisioned yet).
     inferenceRelayURL: ""
 
+    # ── Per-org OIDC SSO plumbing ────────────────────────────────────────────
+    # Required for SSO: the API builds callback URLs as
+    #   {redirectBaseUrl}/api/v1/auth/sso/:orgSlug/callback
+    # Without this the start/callback endpoints return config_error (F11).
+    # The org-level IdP config (discovery URL, client ID/secret) is set per-org
+    # via the API and stored encrypted in the org_sso_configs table.
+    # Authelia is registered as the IdP for the "thekaocloud" org — see the
+    # llmsafespaces OIDC client in networking/authelia/app/helm-release.yaml.
+    oidc:
+      redirectBaseUrl: "https://api.safespaces.dev"
+      frontendRedirectUrl: "https://chat.safespaces.dev"
+
     # ── Subdomain routing ───────────────────────────────────────────────────
     # Disabled — single-host frontend per design call. If we ever want
     # per-org SSO subdomain routing, flip this on and add a wildcard cert.

--- a/kubernetes/apps/networking/authelia/app/helm-release.yaml
+++ b/kubernetes/apps/networking/authelia/app/helm-release.yaml
@@ -892,6 +892,22 @@ spec:
             grant_types:
               - 'authorization_code'
             token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: llmsafespaces
+            client_name: LLMSafeSpaces
+            client_secret: "${SECRET_LLMSPACES_OAUTH_CLIENT_SECRET_HASHED}"
+            public: false
+            authorization_policy: one_factor
+            consent_mode: implicit
+            pre_configured_consent_duration: 1y
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            scopes: ["openid", "profile", "email", "groups"]
+            redirect_uris: ["https://api.${SECRET_SAFESPACES_DOMAIN}/api/v1/auth/sso/thekaocloud/callback"]
+            response_types:
+              - 'code'
+            grant_types:
+              - 'authorization_code'
+            token_endpoint_auth_method: 'client_secret_basic'
             # -
                ## The ID is the OpenID Connect ClientID which is used to link an application to a configuration.
               # id: myapp

--- a/kubernetes/flux/vars/secret.sops.yaml
+++ b/kubernetes/flux/vars/secret.sops.yaml
@@ -87,6 +87,8 @@ stringData:
     SECRET_LIBRECHAT_OAUTH_CLIENT_SECRET_HASHED: ENC[AES256_GCM,data:p/54tOSuV+0NzilCfnXBlG7QBer3+/SMwutG8ejSsdZ27U8ZxE5DGuWBjQZlhP7uORhYFJDyBaipbYPMlhVaz6UcSFbKqQVuOJDnukNGvW0jjFwunMtoaONW3uJSXKuYIi1+dpghAnkOooPJyjydjDZiZ6RDkrA+yJ1bjYWHQIAmf3k=,iv:WBLhdfS+1xRfkVejGnQes/+hTjuH47zqDz6m4rayCtI=,tag:NLRvaFT6m6ITslRAvsAUzw==,type:str]
     SECRET_OPENGIST_OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:+nwb92ddVEy0qC8q0BVFso8aeKtcFx4U4+0oJF7equUZ3K8TTueA/VFeHtVsLyxQQKl9/aAAjbeuY2tkv8C1F12pwlH3nNA/,iv:msBHcZVlJm3PmZQM+FZHqjjC7BnvKfYY7oaAzegYnhk=,tag:fCtjsrpE6mKTewfsgvYNZQ==,type:str]
     SECRET_OPENGIST_OAUTH_CLIENT_SECRET_HASHED: ENC[AES256_GCM,data:P6D8XIUrOBTZc51XPIm8OhJmDSU7KozdtAdJefLqAeqDmbdaMF3DLYTw+XQwFk2e9rCLPn/G0GVN+R3MWuwCnfYd4eidERgTqBF5ZS+CcNZUPE7zG85lPTKMHmnwcQN01cgtSkiwgwX7gQ3c/6qDgmmwNcPmDjMzl2txxgAhCSBpzHA=,iv:yHHc6zeeC/+MOHdpmYu4/EgvGSwMLBT73fZzqxZNYO8=,tag:YIxmqRRS+pPhoI3xZ7yz9g==,type:str]
+    SECRET_LLMSPACES_OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:McBqjpDpCVPClrphjy/uUPJGtRnr3KEyW4AppYX/Mt/ZUrmgH9F8WuTU8lWLlr7E+EbwD5yMDn3VjRMEIMxsDw==,iv:eKIR/+nKe9tTn/HgzzSeaL5xzCQFLmvsJIs9bG/US1E=,tag:fNg8DmFWtBIHqmlcQc8Plw==,type:str]
+    SECRET_LLMSPACES_OAUTH_CLIENT_SECRET_HASHED: ENC[AES256_GCM,data:/GrHbtx66CM/AQ4ZNu4lVBy/4eKhgmqBYDAq8XL41P5KSzfZsNRH49ws8MkpqZjQIb+4Iuj/+R9Ro9xhAzKhhcRexMgnabgr77+Lvgca7+7GCTLL/svEkkpATRLDMQtQQ7Jmh5R630HQSy7bmWu0YDxB1W7ot/efrc82evG6vdqxmre3Xwvgl+k5sJBzTuVCvtSzdaf7SN0RLLG+tmT8OKMGKui+CEUODdcXu7Lwh4Bmy/zkQMnO,iv:6Lh/p/6H2htyB+xeT+YyfO91SCJY8ovjCVtDQHshx44=,tag:x69eAd8JwG18unXk1/lkZQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -102,8 +104,8 @@ sops:
             Qi95aE1OaWMxRDNyUVFGdkR2c0VaYUkKHx3113GJSn/ANejR8mYllitD17kPBdcu
             leuIBWXCVK5J1KEQwPZ4QLj33EluonajGcDK98ytrtGI1M1Qn+jSKA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-30T08:12:31Z"
-    mac: ENC[AES256_GCM,data:IUSHfuhrlbIZIs0AVFEsYttsKMubNkjdhp9tdXeU4HiHXi2BqndR0bAW6X/26kTtWfjvviWu3okUjOTViUkOBoseGKRpB3szZXJ7Hpl+fb7a1EO5T1enWDwdbtH5TyfuIRbVZTuLMdg37eEgFE41R4ndnc+cpvONe5GJI2feJx0=,iv:3VuLFTfL8cYDjOEdPzvLirutdnHmosvtrx2U0OcqzI0=,tag:l0YN2q7oQ8yQFWIk/gnV4A==,type:str]
+    lastmodified: "2026-08-02T07:17:38Z"
+    mac: ENC[AES256_GCM,data:SXDZoUejO3uprrY5j2GZ5MbhJw7tzOF0c4DATTGbGkEyiyL4s0JrLdv3xFVT9MD1WBWAnKNx/udRv6naRUZRF1WQ9a5UNjoeHblqRXG3yVhr2ohahD1j9ZU254+nqY4RVsW33/G0c9orQ3zn4YXg48oPEqnOn8/CEfbTQP+ZoTg=,iv:BgLrWGYLwCVw2+iqwHicP7OTLotxedcYw9JioVZFNa4=,tag:dbKz5ME21edF5P1inuvHew==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.1


### PR DESCRIPTION
## Summary

Enables per-org OIDC SSO for LLMSafeSpace using Authelia as the identity provider (targeting the `thekaocloud` org). Three coordinated changes:

### 1. Authelia OIDC client (`networking/authelia/app/helm-release.yaml`)

New `llmsafespaces` client:
- **PKCE S256** — matches LLMSafeSpace's `go-oidc` PKCE flow (`sso.go:461`)
- **`client_secret_basic`** — matches Go `oauth2.Config` default token exchange
- **Scopes:** `openid, profile, email, groups` — matches what `sso.go` requests; `groups` is needed for role mapping
- **Redirect URI:** `https://api.${SECRET_SAFESPACES_DOMAIN}/api/v1/auth/sso/thekaocloud/callback` — the per-org callback pattern (`{redirectBaseUrl}/api/v1/auth/sso/:orgSlug/callback`)

### 2. LLMSafeSpace OIDC plumbing (`llmsafespaces/llmsafespaces/app/helm-release.yaml`)

Added `oidc.redirectBaseUrl: https://api.safespaces.dev` + `frontendRedirectUrl: https://chat.safespaces.dev`. Without `redirectBaseUrl`, the SSO start/callback endpoints return `config_error` (F11 hardening — the platform refuses to derive from `X-Forwarded-*` headers).

### 3. SOPS cluster secrets (`flux/vars/secret.sops.yaml`)

Added two keys (SOPS-encrypted via `sops --set`, no full decrypt):
- `SECRET_LLMSPACES_OAUTH_CLIENT_SECRET` — plaintext, consumed when configuring the org IdP via the LLMSafeSpace API
- `SECRET_LLMSPACES_OAUTH_CLIENT_SECRET_HASHED` — `$pbkdf2-sha512$310000$...` digest, consumed by Authelia's `client_secret` field (per [Authelia docs](https://www.authelia.com/configuration/identity-providers/openid-connect/clients/))

### Notes

- Secret generated as random 64-char alphanumeric, hashed with PBKDF2-SHA512 / 310000 iterations (same algorithm as `tool_secret_hasher.py`)
- Authelia's existing access-control bypass for `*.safespaces.dev` subdomains is unchanged — LLMSafeSpace manages its own auth
- **Related (separate repo):** LLMSafeSpace frontend now ships a `/sso/:orgSlug` start page (`SSOStartPage.tsx`), so users can share `chat.safespaces.dev/sso/thekaocloud` instead of the full API URL

### Post-merge step

Configure the `thekaocloud` org in LLMSafeSpace via the API with the Authelia discovery URL (`https://authelia.thekao.cloud`), client ID (`llmsafespaces`), and the plaintext client secret.