### PR TITLE
bump(llmsafespaces): v0.7.1 → v0.7.2

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -17,8 +17,8 @@ spec:
         namespace: flux-system
       interval: 15m
       # `reconcileStrategy: Revision` is retained even though the GitRepository
-      # is now pinned to a semver tag (v0.7.1). Rationale: if we ever move a
-      # is now pinned to a semver tag (v0.7.1). Rationale: if we ever move a
+      # is now pinned to a semver tag (v0.7.2). Rationale: if we ever move a
+      # is now pinned to a semver tag (v0.7.2). Rationale: if we ever move a
       # tag or point at a branch during an emergency rollback, ChartVersion
       # would refuse to re-package (Chart.yaml version wouldn't change). With
       # Revision, source-controller re-packages on every commit SHA change,
@@ -88,8 +88,8 @@ spec:
     # (upstream v0.2.0+) the project cuts real semver releases and CI
     # publishes `<major>.<minor>.<patch>` OCI tags alongside the immutable
     # `ts-<unix>` tags. We pin to the semver — the GitRepository above is
-    # pinned to the matching `tag: v0.7.1`, so the chart-source tree and
-    # pinned to the matching `tag: v0.7.1`, so the chart-source tree and
+    # pinned to the matching `tag: v0.7.2`, so the chart-source tree and
+    # pinned to the matching `tag: v0.7.2`, so the chart-source tree and
     # the deployed images roll atomically. To upgrade, bump both the
     # GitRepository ref and every `image.tag` below in the same commit.
     # To verify a semver tag is present on ghcr:
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.7.1"
+        tag: "0.7.2"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.7.1"
+        tag: "0.7.2"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -132,7 +132,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.7.1"
+            tag: "0.7.2"
       freeModelsRefresher:
         enabled: false
 
@@ -203,7 +203,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.7.0`
       # alongside the other four images.
       image:
-        tag: "0.7.1"
+        tag: "0.7.2"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -222,7 +222,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.7.1"
+          tag: "0.7.2"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.7.1
+    tag: v0.7.2
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
Flux GitRepository: v0.7.1 → v0.7.2
Image tags: 0.7.1 → 0.7.2 (5 images)

Ships Image Factory S6/S7/S8 + repolint gin.SetMode gate.