### PR TITLE
fix(cnpg): add backup config to dawarich-postgis to enable barman-cloud backups

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/clusters/dawarich-postgis.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/clusters/dawarich-postgis.yaml
@@ -35,5 +35,24 @@ spec:
     parameters:
       max_connections: "100"
       shared_buffers: 256MB
+  backup:
+    retentionPolicy: 30d
+    barmanObjectStore:
+      wal:
+        compression: bzip2
+        maxParallel: 8
+      destinationPath: "s3://${S3_CNPG}/dawarich-postgis16"
+      endpointURL: http://minio.storage.svc.cluster.local:9000
+      serverName: dawarich-postgis-backup-v01
+      s3Credentials:
+        accessKeyId:
+          name: postgres-minio
+          key: MINIO_ACCESS_KEY
+        secretAccessKey:
+          name: postgres-minio
+          key: MINIO_SECRET_KEY
+        region:
+          name: postgres-minio
+          key: MINIO_REGION
   bootstrap:
     initdb: {}


### PR DESCRIPTION
## Summary

Fixes the dawarich-postgis half of #2161.

The `dawarich-postgis` Cluster manifest had **no `spec.backup` section**, causing every `ScheduledBackup` to fail for **144 days** with `cannot proceed with the backup as the cluster has no backup section`. WAL archiving was also disabled, so there was **no recoverable backup** for dawarich.

This adds a `barmanObjectStore` backup section mirroring `synofotopg` / `vectorpg`:
- 30-day retention (`retentionPolicy: 30d`)
- bzip2 WAL compression, `maxParallel: 8`
- MinIO destination: `s3://${S3_CNPG}/dawarich-postgis16` (existing `cnpg-5wxuej` bucket)
- Credentials from the existing `postgres-minio` Secret (`MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` / `MINIO_REGION`)
- `serverName: dawarich-postgis-backup-v01`

## Verification

- `S3_CNPG` is defined in `kubernetes/flux/vars/cluster-settings.yaml` (= `cnpg-5wxuej`)
- `postgres-minio` Secret exists in `databases` with all three keys
- Pattern matches `synofotopg.yaml` exactly (10 reference matches)
- The `postgis:16` image already ships `barman-cloud-*` binaries (verified in the primary pod), so no image change is needed
- Multi-doc YAML parses cleanly; references use `${}` substitution per repo conventions

## Context (issue #2161)

| Item | Status |
|---|---|
| dawarich-postgis missing `spec.backup` (this PR) | Fixed here |
| `defaultpg` / `llmsafespacespg` stuck replicas on worker-00 | Fixed live (deleted stuck pod+PVC; both now 3/3 healthy on worker-02) |
| `vectorpg` barman-cloud image | Already fixed in `abaeade7` |
| worker-00 openebs-hostpath wipe root cause | Diagnosed: data lives on Talos EPHEMERAL `/var` partition (`/dev/sda6`), wiped during Aug 1 maintenance; longhorn on separate NVMe survived |

## Note

A `github-actions` bot comment on #2161 claimed a PR for this was already opened — **no such PR existed** (open or closed). This is the actual fix.

After merge, the next `ScheduledBackup` run (`0 0 14 * * *` UTC) will take the first full backup.