### PR TITLE
fix(llmsafespaces): empty secretKeyRef.name until Secret exists

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -254,6 +254,10 @@ spec:
     #
     # The LLM explainer key is optional — without it, build failures use
     # a fallback string instead of an LLM-generated explanation.
+    #
+    # NOTE: secretKeyRef.name is left EMPTY until the Secret is created.
+    # If set without the Secret existing, kubelet fails with
+    # CreateContainerError → rollout stalls → Helm rolls back.
     imageFactory:
       imageRepo: "ghcr.io/lenaxia/llmsafespaces/ws"
       callbackURL: "/internal/image-factory"
@@ -263,7 +267,7 @@ spec:
         workflowId: "image-build.yml"
         ref: "main"
         secretKeyRef:
-          name: "image-factory-gh-token"
+          name: ""
           key: "gh-token"
       llmExplainer:
         baseUrl: ""

--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -244,31 +244,27 @@ spec:
     # selecting extensions from an operator-curated catalog. The API
     # renders a Dockerfile and dispatches a GitHub Actions build.
     #
-    # To enable builds: create a Secret with a GitHub PAT (needs repo +
-    # workflow scopes on the LLMSafeSpaces repo) and reference it below.
-    # Without the token, POST /configs returns 503 (graceful degradation —
-    # catalog and settings page still work for browsing).
+    # Auth: GitHub App llmsafespaces-builder (App ID 4470040), installed
+    # on LLMSafeSpaces + llmsafespaces-images. Credentials delivered via
+    # the image-factory-app-credentials Secret (SOPS-encrypted, in this dir).
     #
-    #   kubectl -n llmsafespaces create secret generic image-factory-gh-token \
-    #     --from-literal=gh-token='ghp_xxx'
-    #
-    # The LLM explainer key is optional — without it, build failures use
-    # a fallback string instead of an LLM-generated explanation.
-    #
-    # NOTE: secretKeyRef.name is left EMPTY until the Secret is created.
-    # If set without the Secret existing, kubelet fails with
-    # CreateContainerError → rollout stalls → Helm rolls back.
+    # Images push to ghcr.io/lenaxia/llmsafespaces-images to avoid
+    # cluttering the main repo's package list.
     imageFactory:
-      imageRepo: "ghcr.io/lenaxia/llmsafespaces/ws"
+      imageRepo: "ghcr.io/lenaxia/llmsafespaces-images/ws"
       callbackURL: "/internal/image-factory"
       ghDispatcher:
         owner: "lenaxia"
         repo: "LLMSafeSpaces"
         workflowId: "image-build.yml"
         ref: "main"
-        secretKeyRef:
-          name: ""
-          key: "gh-token"
+        appCredentials:
+          secretName: "image-factory-app-credentials"
+          appIdKey: "app-id"
+          privateKeyKey: "app-private-key"
+      llmExplainer:
+        baseUrl: ""
+        model: ""
       llmExplainer:
         baseUrl: ""
         model: ""

--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/kustomization.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ingress-frontend.yaml
   - ingress-api.yaml
   - middleware-cors.yaml
+  - secret-image-factory.sops.yaml


### PR DESCRIPTION
## Root cause

v0.8.0 rollout failed 6 times with  → Helm auto-rollback to 0.7.2.

The talos-ops-prod HelmRelease set  but the Secret was never created. The chart template renders:

```yaml
- name: LLMSAFESPACES_IMAGE_FACTORY_GH_TOKEN
  valueFrom:
    secretKeyRef:
      name: image-factory-gh-token
      key: gh-token
```

kubelet can't resolve a secretKeyRef to a non-existent Secret →  → pod never starts → never passes readiness → rollout stalls → Helm rolls back.

## Fix

Set  (empty) until the Secret exists. The chart template gates on `{{- if .secretKeyRef.name }}`, so an empty name renders no env var → API starts normally with builds disabled (graceful 503).

## To enable builds later

```bash
kubectl -n llmsafespaces create secret generic image-factory-gh-token \
  --from-literal=gh-token='ghp_xxx'
```

Then set `secretKeyRef.name: image-factory-gh-token` in the HelmRelease.