### PR TITLE
feat(ragnarok): deploy gokore v1.2.0 + gokore-portal

### DIFF
--- a/kubernetes/apps/ragnarok/gokore-portal/configmap.yaml
+++ b/kubernetes/apps/ragnarok/gokore-portal/configmap.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gokore-portal-config
+  namespace: ragnarok
+data:
+  config.yaml: |
+    server:
+      port: 8090
+      dev: false
+
+    gokore:
+      # gRPC endpoint for the gokore bot manager
+      grpc_addr: "gokore.ragnarok.svc.cluster.local:50051"
+
+    community:
+      # Path to the community snapshot (embedded in the portal image)
+      path: "/app/kodata/community"

--- a/kubernetes/apps/ragnarok/gokore-portal/helm-release.yaml
+++ b/kubernetes/apps/ragnarok/gokore-portal/helm-release.yaml
@@ -32,8 +32,8 @@ spec:
             name: gokore-portal
             image:
               repository: ghcr.io/lenaxia/gokore-portal
-              tag: latest
-              pullPolicy: Always
+              tag: v1.2.0
+              pullPolicy: IfNotPresent
             args:
               - -config
               - /config/config.yaml

--- a/kubernetes/apps/ragnarok/gokore-portal/helm-release.yaml
+++ b/kubernetes/apps/ragnarok/gokore-portal/helm-release.yaml
@@ -1,0 +1,91 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &appname gokore-portal
+  namespace: ragnarok
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      interval: 16m
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  values:
+    defaultPodOptions:
+      nodeSelector:
+        node-role.kubernetes.io/worker: 'true'
+
+    controllers:
+      main:
+        enabled: true
+        type: deployment
+        replicas: 1
+        strategy: RollingUpdate
+        containers:
+          main:
+            name: gokore-portal
+            image:
+              repository: ghcr.io/lenaxia/gokore-portal
+              tag: latest
+              pullPolicy: Always
+            args:
+              - -config
+              - /config/config.yaml
+            env:
+              - name: TZ
+                value: ${TIMEZONE}
+            probes:
+              liveness:
+                enabled: true
+                httpGet:
+                  path: /
+                  port: 8090
+                initialDelaySeconds: 10
+                periodSeconds: 30
+              readiness:
+                enabled: true
+                httpGet:
+                  path: /
+                  port: 8090
+                initialDelaySeconds: 5
+                periodSeconds: 10
+
+    service:
+      main:
+        enabled: true
+        primary: true
+        controller: main
+        type: ClusterIP
+        ports:
+          http:
+            port: 8090
+            enabled: true
+
+    persistence:
+      config:
+        enabled: true
+        type: configMap
+        name: gokore-portal-config
+        globalMounts:
+          - path: /config
+
+    ingress:
+      main:
+        enabled: true
+        className: traefik
+        annotations:
+          traefik.ingress.kubernetes.io/router.middlewares: networking-chain-authelia@kubernetescrd
+        hosts:
+          - host: gokore-portal.${SECRET_DEV_DOMAIN}
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  name: *appname
+                  port: 8090

--- a/kubernetes/apps/ragnarok/gokore-portal/ingress.yaml
+++ b/kubernetes/apps/ragnarok/gokore-portal/ingress.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gokore-portal
+  namespace: ragnarok
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: networking-chain-authelia@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: gokore-portal.${SECRET_DEV_DOMAIN}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gokore-portal
+                port:
+                  number: 8090
+  tls:
+    - hosts:
+        - gokore-portal.${SECRET_DEV_DOMAIN}
+      secretName: gokore-portal-tls

--- a/kubernetes/apps/ragnarok/gokore-portal/ks.yaml
+++ b/kubernetes/apps/ragnarok/gokore-portal/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gokore-portal
+  namespace: flux-system
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  targetNamespace: ragnarok
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/ragnarok/gokore-portal
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops
+  dependsOn:
+    - name: gokore
+      namespace: flux-system
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: gokore-portal
+      namespace: ragnarok
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ragnarok/gokore-portal/kustomization.yaml
+++ b/kubernetes/apps/ragnarok/gokore-portal/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helm-release.yaml
+  - ./configmap.yaml
+  - ./ingress.yaml

--- a/kubernetes/apps/ragnarok/gokore/config-pvc.yaml
+++ b/kubernetes/apps/ragnarok/gokore/config-pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gokore-config
+  namespace: ragnarok
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/ragnarok/gokore/configmap.yaml
+++ b/kubernetes/apps/ragnarok/gokore/configmap.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gokore-config-files
+  namespace: ragnarok
+data:
+  config.yaml: |
+    network:
+      packet_ver: 20200401
+      region: "kRO"
+      server_address: "rathena-renewal.ragnarok.svc.cluster.local:6900"
+      connection_timeout: 30
+      retry_count: 3
+      retry_delay: 1000
+
+    bot_manager:
+      enabled: true
+      bot_count: 50
+      spawn_delay: 3000
+
+    auth:
+      username_template: "botijo{1}"
+      password: "Melon.77"
+      character:
+        select_mode: "auto"
+        index: 0
+
+    log:
+      level: "info"
+      format: "text"
+
+    ai:
+      enabled: true
+      behaviors:
+        random_walk:
+          enabled: true
+          destination_max_distance: 50
+          destination_min_distance: 20
+
+    community:
+      snapshot_path: "/config/community.json"
+
+    cognitive:
+      enabled: true
+      llm_provider: "openai"
+      reactive_mode: true
+      strategic_mode: true
+      strategy_interval: 90
+      fleet_slots: 60
+      fsm_end_conversation_coercion: 0.4
+      fsm_max_chunks_soft_limit: 12
+
+    llm:
+      base_url: "https://ai.thekao.cloud/v1"
+      models:
+        strong: "glm-5.2"
+        medium: "classifier"
+        weak: "classifier"
+      reactive_workers: 12
+      strategic_workers: 6
+      disable_thinking: true
+      max_retries: 2
+      retry_base_delay: 2s
+      retry_max_delay: 15s
+      breaker_threshold: 10
+      breaker_reset_timeout: 60s

--- a/kubernetes/apps/ragnarok/gokore/helm-release.yaml
+++ b/kubernetes/apps/ragnarok/gokore/helm-release.yaml
@@ -1,0 +1,98 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &appname gokore
+  namespace: ragnarok
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      interval: 16m
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  values:
+    defaultPodOptions:
+      nodeSelector:
+        node-role.kubernetes.io/worker: 'true'
+
+    controllers:
+      main:
+        enabled: true
+        type: deployment
+        replicas: 1
+        strategy: Recreate
+        containers:
+          main:
+            name: gokore
+            image:
+              repository: ghcr.io/lenaxia/gokore
+              tag: v1.2.0
+              pullPolicy: IfNotPresent
+            args:
+              - -config-dir
+              - /config
+              - -log-level
+              - info
+            envFrom:
+              - secretRef:
+                  name: gokore
+            env:
+              - name: TZ
+                value: ${TIMEZONE}
+              - name: RATHENA_DB_PATH
+                value: /data/db
+              - name: OPENAI_API_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: gokore
+                    key: OPENAI_API_KEY
+            probes:
+              liveness:
+                enabled: true
+                httpGet:
+                  path: /healthz
+                  port: 9090
+                initialDelaySeconds: 30
+                periodSeconds: 30
+              readiness:
+                enabled: true
+                httpGet:
+                  path: /readyz
+                  port: 9090
+                initialDelaySeconds: 10
+                periodSeconds: 10
+
+    service:
+      main:
+        enabled: true
+        primary: true
+        controller: main
+        type: ClusterIP
+        ports:
+          http:
+            port: 9090
+            enabled: true
+          grpc:
+            port: 50051
+            enabled: true
+
+    persistence:
+      config:
+        enabled: true
+        type: persistentVolumeClaim
+        name: gokore-config
+        globalMounts:
+          - path: /config
+      data:
+        enabled: true
+        type: configMap
+        name: gokore-config-files
+        defaultMode: 0755
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/ragnarok/gokore/ks.yaml
+++ b/kubernetes/apps/ragnarok/gokore/ks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gokore
+  namespace: flux-system
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  targetNamespace: ragnarok
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/ragnarok/gokore
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops
+  dependsOn:
+    - name: cluster-ragnarok-rathena-renewal
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: gokore
+      namespace: ragnarok
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ragnarok/gokore/kustomization.yaml
+++ b/kubernetes/apps/ragnarok/gokore/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helm-release.yaml
+  - ./config-pvc.yaml
+  - ./configmap.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/ragnarok/gokore/secret.sops.yaml
+++ b/kubernetes/apps/ragnarok/gokore/secret.sops.yaml
@@ -1,20 +1,28 @@
-# NOTE: This file MUST be encrypted with SOPS before committing.
-# The age key (age.key) and sops CLI are required.
-#
-# To encrypt:
-#   1. Install sops: https://github.com/getsops/sops#download
-#   2. Place the age key file at the repo root as `age.key`
-#   3. Run: sops --encrypt --in-place kubernetes/apps/ragnarok/gokore/secret.sops.yaml
-#
-# Until encrypted, this file should NOT be committed. The values below
-# are placeholders — replace OPENAI_API_KEY with the real secret before
-# encrypting.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: gokore
-  namespace: ragnarok
+    name: gokore
+    namespace: ragnarok
 stringData:
-  # OpenAI-compatible API key for the LLM endpoint (ai.thekao.cloud)
-  OPENAI_API_KEY: "REPLACE_BEFORE_ENCRYPTING"
+    OPENAI_API_KEY: ENC[AES256_GCM,data:Asbqx3C8XLvR0GHwfHjcF4HPvzTMx3nuDVWpwvPLw8ePNiSu,iv:HzJiGIA6evxEej9t94G7DfWeIJSI5m96jX+K0SPVmxc=,tag:h4uptw3qRUXSDkI0EKU8eg==,type:str]
 type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1rr569v9jm7ck70q4wpnspfhdvt4y5m6s604tx0ygs0a65qkt7g4qdszk6k
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4QVkwbjM5WFg0TTY4Z01D
+            R2ludjNhOWZMbFdYNjgyQ2JrREVZd3d2c1E4CnhQbTZSZy9VaG5seDZZc2R5d1Y1
+            dS93Tmt4L3NsZW5veXMyMEs3OG9NOUEKLS0tIFhVai9ESDFWTzVXMTh4c3Zna0g5
+            UDBUUzJPRlYvRGE3ZDkzSEc1ZGY4OXMK4MPVncJZ2mjd7njwwL3JqtjUwbJdtsyS
+            me8QWxgoD2RI/iptmyiVcCig0BfdtGpNPkAAZbE8Y+UWXNb8iBYsXw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-08-03T05:40:14Z"
+    mac: ENC[AES256_GCM,data:kGYwRvQQizikFBQop8uP3ALJjknXEqVGXJoon5qYM8Uxd7TNdG+N7rvuzzmwwOrGjeoDz3bmXOTj+X7+vAzQAcRV0JDYzZF92K4MTScf7KdowVzh1jHnmfHeCCNFTEHu7tRw/f894PBNwAb5FYWLdQ/i7TlNHJrtCCLEFvN/epo=,iv:BjzARzYOS3nqx8y2D7FQR4ycI3bO5cg/6H/LjPG80hE=,tag:jXPOqi/OYwjbFnzG4L6f5w==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.9.2

--- a/kubernetes/apps/ragnarok/gokore/secret.sops.yaml
+++ b/kubernetes/apps/ragnarok/gokore/secret.sops.yaml
@@ -1,0 +1,20 @@
+# NOTE: This file MUST be encrypted with SOPS before committing.
+# The age key (age.key) and sops CLI are required.
+#
+# To encrypt:
+#   1. Install sops: https://github.com/getsops/sops#download
+#   2. Place the age key file at the repo root as `age.key`
+#   3. Run: sops --encrypt --in-place kubernetes/apps/ragnarok/gokore/secret.sops.yaml
+#
+# Until encrypted, this file should NOT be committed. The values below
+# are placeholders — replace OPENAI_API_KEY with the real secret before
+# encrypting.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gokore
+  namespace: ragnarok
+stringData:
+  # OpenAI-compatible API key for the LLM endpoint (ai.thekao.cloud)
+  OPENAI_API_KEY: "REPLACE_BEFORE_ENCRYPTING"
+type: Opaque

--- a/kubernetes/apps/ragnarok/kustomization.yaml
+++ b/kubernetes/apps/ragnarok/kustomization.yaml
@@ -5,5 +5,7 @@ resources:
   - ./namespace.yaml
   - ./rathena/ks.yaml
   - ./roskills/ks.yaml
-    #- ./openkore/ks.yaml
+  #- ./openkore/ks.yaml
   - ./robrowserlegacy/ks.yaml
+  - ./gokore/ks.yaml
+  - ./gokore-portal/ks.yaml


### PR DESCRIPTION
## Summary

Deploys gokore v1.2.0 (50-bot cognitive framework) and gokore-portal to the ragnarok namespace, connecting to the existing rathena-renewal server.

## Changes

### gokore deployment
- **Image:** `ghcr.io/lenaxia/gokore:v1.2.0`
- **Namespace:** `ragnarok` (dependsOn `cluster-ragnarok-rathena-renewal`)
- **Config:** 50 bots, cognitive LLM (classifier model), FSM social interactions, 50-character community snapshot (seed 42)
- **FSM knobs:** end_conversation_coercion=0.4, max_chunks_soft_limit=12, breaker tuning
- **Ports:** gRPC 50051 (management), HTTP 9090 (observability)
- **Health probes:** `/healthz`, `/readyz`
- **PVC:** 1Gi for config persistence
- **ConfigMap:** full gokore config (network, auth, cognitive, LLM pool, community)

### gokore-portal deployment
- **Image:** `ghcr.io/lenaxia/gokore-portal:latest`
- **Namespace:** `ragnarok` (dependsOn `gokore`)
- **Ingress:** `gokore-portal.${SECRET_DEV_DOMAIN}` (Authelia-protected)
- **Connects to gokore via gRPC**

## ⚠️ Pre-merge action required

The `secret.sops.yaml` contains a **placeholder** `OPENAI_API_KEY`. Before merging:

1. Install `sops` and place `age.key` at repo root
2. Edit the secret with the real API key
3. Encrypt: `sops --encrypt --in-place kubernetes/apps/ragnarok/gokore/secret.sops.yaml`
4. Verify: `grep "ENC\[" kubernetes/apps/ragnarok/gokore/secret.sops.yaml` returns a match

## Files

```
kubernetes/apps/ragnarok/gokore/
  ks.yaml              # Flux Kustomization (dependsOn rathena-renewal)
  kustomization.yaml
  helm-release.yaml    # app-template v5.0.1, gokore:v1.2.0
  configmap.yaml       # gokore config + community
  config-pvc.yaml      # 1Gi PVC
  secret.sops.yaml     # OPENAI_API_KEY (NEEDS SOPS ENCRYPTION)

kubernetes/apps/ragnarok/gokore-portal/
  ks.yaml              # Flux Kustomization (dependsOn gokore)
  kustomization.yaml
  helm-release.yaml    # app-template, gokore-portal:latest
  configmap.yaml       # portal config
  ingress.yaml         # Traefik ingress + Authelia
```