### PR TITLE
fix(monitoring,kyverno): pin prometheus to workers, fix pvc-reaper RBAC, co-locate kopia backup jobs

### DIFF
--- a/kubernetes/apps/kyverno/policies/snapshot-cronjob-controller.yaml
+++ b/kubernetes/apps/kyverno/policies/snapshot-cronjob-controller.yaml
@@ -37,18 +37,6 @@ spec:
         - name: namespace
           variable:
             jmesPath: "request.object.metadata.namespace"
-        - name: nodeAffinity
-          variable:
-            value:
-              labels:
-                - key: app.kubernetes.io/name
-                  operator: "In"
-                  values:
-                    - "{{ request.object.metadata.labels.\"app.kubernetes.io/name\" }}"
-                - key: app.kubernetes.io/instance
-                  operator: "In"
-                  values:
-                    - "{{ request.object.metadata.labels.\"app.kubernetes.io/instance\" }}"
       generate:
         generateExisting: true
         synchronize: true
@@ -80,6 +68,24 @@ spec:
                   spec:
                     automountServiceAccountToken: false
                     restartPolicy: OnFailure
+                    # Co-locate with the app pod that owns the PVC.  The backup
+                    # mounts the live RWO volume, which is already attached to
+                    # the app's node — without this affinity the job lands on a
+                    # random node and fails with "Multi-Attach error".
+                    affinity:
+                      podAffinity:
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          - labelSelector:
+                              matchExpressions:
+                                - key: app.kubernetes.io/name
+                                  operator: In
+                                  values:
+                                    - "{{ request.object.metadata.labels.\"app.kubernetes.io/name\" }}"
+                                - key: app.kubernetes.io/instance
+                                  operator: In
+                                  values:
+                                    - "{{ request.object.metadata.labels.\"app.kubernetes.io/instance\" }}"
+                            topologyKey: kubernetes.io/hostname
                     # Stagger jobs to run randomly within X seconds to avoid bringing down all apps at once
                     containers:
                       - name: snapshot

--- a/kubernetes/apps/monitoring/prometheus-stack/app/helm-release.yaml
+++ b/kubernetes/apps/monitoring/prometheus-stack/app/helm-release.yaml
@@ -236,6 +236,12 @@ spec:
         replicas: 3
         shards: 1
         retention: 15d
+        # Pin to worker nodes: storage uses openebs-hostpath (node-local) and
+        # Longhorn CSI only runs on workers.  Without this the scheduler can
+        # place replicas on control-planes where neither storage backend is
+        # available, leaving pods stuck in Init forever.
+        nodeSelector:
+          node-role.kubernetes.io/worker: "true"
         podMonitorSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
         ruleSelectorNilUsesHelmValues: false

--- a/kubernetes/apps/monitoring/pvc-reaper/app/rbac.yaml
+++ b/kubernetes/apps/monitoring/pvc-reaper/app/rbac.yaml
@@ -35,7 +35,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "delete"]
+    verbs: ["get", "list", "watch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary

Three fixes for issues surfaced during cluster health cleanup after the worker-00 openebs-hostpath wipe (issue #2161 investigation).

### 1. Prometheus pinned to worker nodes
**Problem:** The Prometheus StatefulSet tolerated control-plane taints (chart default), so the scheduler placed replicas on `cp-00`/`cp-02`. But Longhorn CSI only runs on workers — those pods could never mount their PVCs and stayed stuck in `Init:0/1` for 33h. Only 1 of 3 replicas recovered (landed on worker-02 by luck).

**Fix:** Add `nodeSelector: node-role.kubernetes.io/worker: "true"` to `prometheusSpec`. All replicas now schedule exclusively on workers where both `openebs-hostpath` and Longhorn CSI are available.

### 2. pvc-reaper RBAC — add `watch` verb
**Problem:** The pvc-reaper CronJob (designed to auto-clean stuck openebs-hostpath PVCs on node loss) has been completely non-functional since deployment. Its ServiceAccount lacks `watch` on PVCs:
```
forbidden: User "system:serviceaccount:monitoring:pvc-reaper" cannot watch resource "persistentvolumeclaims"
```
Every 10-minute run for 35h died in an infinite retry loop. This is why the broken Prometheus PVCs were never auto-reaped — the safety net designed for exactly this scenario was broken.

**Fix:** Add `"watch"` to the PVC Role verbs (`get, list, delete` → `get, list, watch, delete`).

### 3. Kyverno Kopia backup jobs — add podAffinity
**Problem:** The `snapshot-cronjob-controller` ClusterPolicy generates daily Kopia backup CronJobs that mount the app's live RWO PVC. But the generated pod had no affinity, so the scheduler placed it on a random node. Since the RWO volume is already attached to the app pod's node, the job failed with:
```
Multi-Attach error for volume "pvc-..." Volume is already used by pod(s) fmd2-596bb85478-ln944
```
7 of ~20 daily backup jobs were permanently stuck on this.

**Fix:** Add `podAffinity.requiredDuringSchedulingIgnoredDuringExecution` matching the app's `app.kubernetes.io/name` + `app.kubernetes.io/instance` labels with `topologyKey: kubernetes.io/hostname`. This forces the backup job onto the same node as the app pod that holds the PVC. Also removes the unused/broken `nodeAffinity` context variable that was defined but never applied to the pod spec.

## Verification
- All 3 files pass multi-doc YAML validation
- `prometheus-1` confirmed Running on worker-02 after manual PVC rebuild (this PR makes that the norm, not luck)
- `pvc-reaper` RBAC error reproduced exactly from logs (`cannot watch resource persistentvolumeclaims`)
- Kopia `Multi-Attach error` reproduced from live pod events

## Risk
- **Prometheus:** Low — 4 healthy workers available, pods will schedule immediately. Existing control-plane toleration becomes a no-op.
- **pvc-reaper:** Low — adds a verb, doesn't change existing behavior. The reaper only deletes PVCs on NotReady nodes.
- **Kyverno:** Medium — `synchronize: true` means Kyverno will update all ~20 generated CronJobs on apply. Existing backup jobs will gain affinity; next run at 12:00 UTC will co-locate correctly. Jobs whose apps have no matching pod (e.g. scaled to 0) will stay Pending until the app returns — this is correct behavior (can't back up a volume with no consumer).

Refs #2161 (cluster health investigation)