### PR TITLE
fix(kyverno): rename snapshot-cronjob rule to bypass generate-rule immutability

### DIFF
--- a/kubernetes/apps/kyverno/policies/snapshot-cronjob-controller.yaml
+++ b/kubernetes/apps/kyverno/policies/snapshot-cronjob-controller.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   mutateExistingOnPolicyUpdate: true
   rules:
-    - name: create-snapshot-cronjob2
+    - name: create-snapshot-cronjob3
       match:
         any:
           - resources:


### PR DESCRIPTION
## Summary

Follow-up to PR #2166. The Kyverno `snapshot-cronjob-controller` ClusterPolicy could not be updated in place because Kyverno's admission webhook denies changes to immutable fields of generate rules:

```
admission webhook "validate-policy.kyverno.svc" denied the request:
changes of immutable fields of a rule spec in a generate rule is disallowed
```

The podAffinity addition from #2166 (which co-locates Kopia backup jobs with their PVC owner) is blocked from applying.

**Fix:** Rename the rule from `create-snapshot-cronjob2` → `create-snapshot-cronjob3`. Kyverno treats this as a new generation rule. With `synchronize: true`, it will delete the old generated CronJobs and recreate them with the correct podAffinity that prevents Multi-Attach errors.

## Verification
- Flux confirmed the error: `ClusterPolicy/kyverno/snapshot-cronjob-controller dry-run failed: admission webhook "validate-policy.kyverno.svc" denied the request`
- YAML validated
- The pvc-reaper `watch` verb and Prometheus `nodeSelector` from #2166 are already applied live (confirmed)

Refs #2161