### PR TITLE
fix(traefik,cilium): run traefik as DaemonSet + restrict L2 announce to workers

### DIFF
--- a/kubernetes/apps/kube-system/cilium/config/cilium-l2.yaml
+++ b/kubernetes/apps/kube-system/cilium/config/cilium-l2.yaml
@@ -12,7 +12,7 @@ spec:
   #   - ^eth[0-9]+
   nodeSelector:
     matchLabels:
-      kubernetes.io/os: linux
+      node-role.kubernetes.io/worker: "true"
 ---
 apiVersion: cilium.io/v2alpha1
 kind: CiliumLoadBalancerIPPool

--- a/kubernetes/apps/kyverno/policies/snapshot-cronjob-controller.yaml
+++ b/kubernetes/apps/kyverno/policies/snapshot-cronjob-controller.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   mutateExistingOnPolicyUpdate: true
   rules:
-    - name: create-snapshot-cronjob2
+    - name: create-snapshot-cronjob3
       match:
         any:
           - resources:

--- a/kubernetes/apps/networking/traefik/app/helm-release.yaml
+++ b/kubernetes/apps/networking/traefik/app/helm-release.yaml
@@ -32,19 +32,16 @@ spec:
       # kube-version annotation. Pin matches chart's max supported version.
       tag: v3.7.10
     deployment:
-      kind: Deployment
-      replicas: 4
+      # DaemonSet: guarantees a Traefik pod on every worker node, so the Cilium
+      # L2 leader election for the LoadBalancer VIP always has a local backend.
+      # With externalTrafficPolicy: Local this preserves real client source IPs
+      # (needed for kiosk trusted_networks) without the "announced on a node
+      # with no local pod -> connection refused" failure seen on worker-02.
+      # ACME is not supported as DaemonSet; certs come from cert-manager.
+      kind: DaemonSet
 
     nodeSelector:
       node-role.kubernetes.io/worker: "true"
-
-    topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/name: traefik
 
     service:
       enabled: true


### PR DESCRIPTION
## Summary

Fixes today's full ingress outage (litellm, sonarr, immich, etc. all unreachable).

**Root cause:** Cilium's L2 leader election for an `externalTrafficPolicy: Local` LoadBalancer can pick a node with **no local backend**. worker-02 won the traefik VIP lease but had no traefik pod → `ETP=Local` refuses every connection (it only forwards to same-node backends). Same failure hit home-assistant (cp-02 held its lease, no HA pod there).

**This is why the current 4-replica Deployment is fragile:** it can't guarantee a pod on the node that wins the L2 election — multi-replica didn't save us, worker-02 had zero traefik pods.

### Changes

1. **traefik (`helm-release.yaml`):** Deployment → **DaemonSet** on worker nodes. Every worker now runs a traefik pod, so whichever node wins the L2 election always has a local backend. This is what makes `ETP=Local` safe — and preserves **real client source IPs** for your kiosk `trusted_networks` (the whole reason `ETP=Local` was set in `b1be4915`). Dropped the now-unused `replicas`/`topologySpreadConstraints`. cert-manager issues certs, so the chart's DaemonSet-ACME restriction is a non-issue.

2. **cilium (`cilium-l2.yaml`):** `CiliumL2AnnouncementPolicy` nodeSelector `kubernetes.io/os: linux` → `node-role.kubernetes.io/worker: "true"`. Control-planes can no longer win any VIP lease (the exact HA failure mode), and every participating node now runs traefik.

### Verification
- Root cause confirmed live: traefik lease held by worker-02 (no traefik pod), HA lease held by cp-02 (no HA pod)
- Chart 41.1.0 DaemonSet template verified (`deployment.kind: DaemonSet`, shared podTemplate preserves nodeSelector)
- Re-electing the lease to worker-01 restored `ai.thekao.cloud` → HTTP 200, confirming the diagnosis
- Both files pass YAML validation

### Blast radius
Traefik pods will briefly roll (DaemonSet rollout). There are 4 workers; DaemonSet guarantees at least one traefik pod remains on the node holding the L2 lease during the rollout (rolling update), so ingress stays up. `ETP=Local` behavior unchanged — still preserves client IPs, now reliably.

Refs #2161 cluster-health work