### PR TITLE
fix(home-assistant): revert externalTrafficPolicy to Cluster

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helm-release.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helm-release.yaml
@@ -123,7 +123,7 @@ spec:
       main:
         type: LoadBalancer
           #externalIPs: ["${SVC_HOME_ASSISTANT_ADDR}"]
-        externalTrafficPolicy: Local
+        externalTrafficPolicy: Cluster
         ports:
           http:
             port: 8123


### PR DESCRIPTION
## Summary

Reverts `ed1e1e70` which set `externalTrafficPolicy: Local` on the home-assistant LoadBalancer.

HA is single-replica by design (not HA mode), so ETP=Local has no redundancy benefit and is strictly fragile: the Cilium L2 leader election for the HA VIP can land on a node without the HA pod (today: cp-02 held the lease), and ETP=Local then refuses all traffic — the LB was unreachable for the entire outage. This is the same failure mode that took down Traefik ingress (fixed in #2168 by switching to DaemonSet, which isn't appropriate for a stateful single-replica app).

ETP=Cluster lets Cilium forward to the HA pod on any node regardless of which worker holds the L2 lease, restoring reliability.

## Trade-off

ETP=Cluster means the LB SNATs the source IP, so HA sees the forwarding node IP rather than the kiosk's real LAN IP. If `trusted_networks` in HA's config matches the kiosk's direct LAN IP, it will need to be updated to trust the cluster node CIDR (or the kiosk should connect via hass.thekao.cloud through Traefik, which sets X-Forwarded-For).

## Verification
- Failure confirmed live: HA LB (192.168.5.131) timed out while lease was held by cp-02 (no HA pod); only reachable via Traefik
- One-line change, YAML diff clean

Refs #2161 cluster-health work