### PR TITLE
fix(kyverno): use matchExpressions instead of wildcard matchLabels to fix JMESPath parse error

### DIFF
--- a/kubernetes/apps/kyverno/policies/snapshot-cronjob-controller.yaml
+++ b/kubernetes/apps/kyverno/policies/snapshot-cronjob-controller.yaml
@@ -21,10 +21,15 @@ spec:
               kinds:
                 - PersistentVolumeClaim
               selector:
-                matchLabels:
-                  app.kubernetes.io/name: "*"
-                  app.kubernetes.io/instance: "*"
-                  snapshot.home.arpa/enabled: "true"
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: Exists
+                  - key: app.kubernetes.io/instance
+                    operator: Exists
+                  - key: snapshot.home.arpa/enabled
+                    operator: In
+                    values:
+                      - "true"
       context:
         - name: appName
           variable:


### PR DESCRIPTION
## Summary

The `snapshot-cronjob-controller` ClusterPolicy's match selector used `matchLabels` with `*` wildcard values. Kyverno 1.18.x parses label selector values through its JMESPath engine during `generateExisting` resource discovery, and `*` (a JMESPath projection operator) produces an incomplete expression — causing an **hourly error since Aug 1** that silently broke all Kopia backup CronJob generation:

```
ERR policy_controller.go:605 failed to list matched resource error="found '<', expected: !, identifier, or 'end of string'"
```

With this error, the policy controller could not enumerate matching PVCs, so no `UpdateRequests` were created and `generateExisting` never fired. The snap CronJobs that existed were stale remnants from before the error started.

### Fix

Replace wildcard `matchLabels` with standard `matchExpressions`:
- `app.kubernetes.io/name`: `Exists`
- `app.kubernetes.io/instance`: `Exists`
- `snapshot.home.arpa/enabled`: `In ["true"]`

This avoids the JMESPath parsing path entirely and uses correct Kubernetes label-selector semantics.

### Verification
- Confirmed 23 of 25 labeled PVCs have `name` + `instance` labels (the other 2 would fail generation anyway since the policy uses those labels for CronJob naming and podAffinity)
- The `match` block is not part of Kyverno's generate-rule immutability constraint (only `generate.data` is immutable), so Flux should apply this in-place without needing a delete+recreate
- Pre-existing since Aug 1 (correlates with cluster outage), not caused by today's work

Refs #2161