### PR TITLE
chore(fission): disable 4 broken job-scraper functions

### DIFF
--- a/kubernetes/apps/fission/fission/functions/kustomization.yaml
+++ b/kubernetes/apps/fission/fission/functions/kustomization.yaml
@@ -12,11 +12,15 @@ resources:
   # Generic violetscans Package + per-series Function CRs.
   # See ./violetscans/README.md for how to add a new series.
   - ./violetscans
-  - ./job-scraper-stripe.yaml
+  # Disabled 2026-08-07: broken. crowdstrike/stripe/vanta return 404 fetching
+  # package from github.com/lenaxia/functions/releases; snowflake references the
+  # non-existent `python3-playwright` environment. Secrets kept below so
+  # re-enabling is trivial once upstream packages/env are restored.
   - ./secret-job-scraper-stripe.sops.yaml
-  - ./job-scraper-vanta.yaml
   - ./secret-job-scraper-vanta.sops.yaml
-  - ./job-scraper-crowdstrike.yaml
   - ./secret-job-scraper-crowdstrike.sops.yaml
-  - ./job-scraper-snowflake.yaml
   - ./secret-job-scraper-snowflake.sops.yaml
+  # - ./job-scraper-stripe.yaml
+  # - ./job-scraper-vanta.yaml
+  # - ./job-scraper-crowdstrike.yaml
+  # - ./job-scraper-snowflake.yaml

--- a/kubernetes/apps/fission/fission/httptriggers/kustomization.yaml
+++ b/kubernetes/apps/fission/fission/httptriggers/kustomization.yaml
@@ -11,11 +11,13 @@ resources:
   - ./imaizumi-timer.yaml
   # Generic violetscans triggers — one directory per series.
   - ./violetscans
-  - ./job-scraper-stripe.yaml
-  - ./job-scraper-stripe-timer.yaml
-  - ./job-scraper-vanta.yaml
-  - ./job-scraper-vanta-timer.yaml
-  - ./job-scraper-crowdstrike.yaml
-  - ./job-scraper-crowdstrike-timer.yaml
-  - ./job-scraper-snowflake.yaml
-  - ./job-scraper-snowflake-timer.yaml
+  # Disabled 2026-08-07: corresponding functions are broken (404 fetching
+  # package / missing env). See ../functions/kustomization.yaml.
+  # - ./job-scraper-stripe.yaml
+  # - ./job-scraper-stripe-timer.yaml
+  # - ./job-scraper-vanta.yaml
+  # - ./job-scraper-vanta-timer.yaml
+  # - ./job-scraper-crowdstrike.yaml
+  # - ./job-scraper-crowdstrike-timer.yaml
+  # - ./job-scraper-snowflake.yaml
+  # - ./job-scraper-snowflake-timer.yaml


### PR DESCRIPTION
## Summary

Disables 4 broken Fission functions that are currently CrashLoopBackoff / undeployable in the cluster.

| Function | Root cause |
|---|---|
| `job-scraper-crowdstrike` | 404 fetching package zip from `github.com/lenaxia/functions/releases/latest/download/job-scraper-crowdstrike-1.0.0.zip` |
| `job-scraper-stripe` | same 404 (different zip name) |
| `job-scraper-vanta` | same 404 (different zip name) |
| `job-scraper-snowflake` | references non-existent environment `python3-playwright` — no deployment even created |

## Changes

- `kubernetes/apps/fission/fission/functions/kustomization.yaml` — commented out the 4 `job-scraper-*.yaml` Function CR entries; **kept** the 4 `secret-job-scraper-*.sops.yaml` entries so secrets stay applied.
- `kubernetes/apps/fission/fission/httptriggers/kustomization.yaml` — commented out all 8 HTTP/Time trigger entries for the 4 functions.

Manifest files themselves are untouched on disk — re-enabling is just uncommenting once upstream packages are restored and/or the `python3-playwright` environment is added.

## Post-merge

Flux will prune the live `Function`, `HTTPTrigger`, and `TimeTrigger` CRs on next reconcile (`ks.yaml` has `prune: true`). Fission's executor will then tear down the three crashlooping `newdeploy-job-scraper-*` pods.

Healthy functions (`hello`, `imaizumi`, `matriarch`, `matriarch-vy`, `may-i-please`) are untouched.

## Validation

- `kustomize build` on both affected kustomizations succeeds and emits only healthy resources (verified locally).
- No secret files modified or decrypted.