### PR TITLE
bump(llmsafespaces): v0.8.10 → v0.8.11

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.8.10"
+        tag: "0.8.11"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.8.10"
+        tag: "0.8.11"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -132,7 +132,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.8.10"
+            tag: "0.8.11"
       freeModelsRefresher:
         enabled: false
 
@@ -203,7 +203,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.8.10"
+        tag: "0.8.11"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -222,7 +222,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.8.10"
+          tag: "0.8.11"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.8.10
+    tag: v0.8.11
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
Flux GitRepository: v0.8.10 -> v0.8.11
Image tags: 0.8.10 -> 0.8.11 (5 images)

Ships image factory org/platform scopes (#664/#667), restriction policy (#668), mobile settings scroll fix (#658), Epic 64 triggers/workflows.