### PR TITLE
fix(outline): wire SMTP vars to SECRET_SMTP_* family to unblock Flux

### DIFF
--- a/kubernetes/apps/media/outline/app/patches/env.yaml
+++ b/kubernetes/apps/media/outline/app/patches/env.yaml
@@ -61,11 +61,17 @@ spec:
               - name: PORT
                 value: 3000
               - name: SMTP_HOST
-                value: ${SECRET_SMTP_HOST_GMAIL}
+                value: ${SECRET_SMTP_HOST}
               - name: SMTP_PORT
-                value: 587
-                  #- name: #SMTP_FROM_EMAIL
-                #  value: "outline@${SECRET_DEV_DOMAIN}"
+                value: ${SECRET_SMTP_PORT}
+              - name: SMTP_USERNAME
+                value: ${SECRET_SMTP_USERNAME}
+              - name: SMTP_PASSWORD
+                value: ${SECRET_SMTP_PASSWORD}
+              - name: SMTP_FROM_EMAIL
+                value: ${SECRET_SMTP_FROM_ADDR}
+              - name: SMTP_FROM_NAME
+                value: ${SECRET_SMTP_FROM_NAME}
               - name: SMTP_SECURE
                 value: "false"
               - name: URL

--- a/kubernetes/apps/media/outline/app/secret.sops.yaml
+++ b/kubernetes/apps/media/outline/app/secret.sops.yaml
@@ -6,16 +6,14 @@ metadata:
     namespace: default
 type: Opaque
 stringData:
-    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:8xO2Ybxl3OVTHez51wKUzEE=,iv:T8lTleJoCHolSZbjO2uhGWfAPnPJ7aqeSNHoiBwGM4w=,tag:WafMqR9WA1DSdbUFeOTf5A==,type:str]
-    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:6KIstAGn/lxuVw+OnJJF3pv6q08=,iv:g6ELjz6uyQHa94nXU3OGt7lkrMukehG9BfAOuSta/Dc=,tag:xAHay1i8QzHAnEYhiRUZSQ==,type:str]
-    SECRET_KEY: ENC[AES256_GCM,data:ELEBswlSnTSscwL/LcL/K6zmfZhf9sGmTosyjVxkbATvQnVH9GYnDJT2pt4FhAqUL6FaZ+68pzvrPrXKpBVKiA==,iv:NEERfP8D+GN5/JrMLkgcD9APUQfEiK8FUZJQEprhBfg=,tag:+QkZsFuLSENGp6OFF1thGA==,type:str]
-    UTILS_SECRET: ENC[AES256_GCM,data:dRBiCL0IzY83IpHh8jKJie6iiseuZZGqGUVg8fAcrWfgq9EPQhJiSskAuMG6OH+ZPPuawSnoJAKy7eBqZ1oAXw==,iv:AT4A9Dv+vAEkJS7+wJmrhlwlkxZPGSCUX+jZeYN8Uik=,tag:H88Iw0i4XLBtWIlHK4w2dQ==,type:str]
-    DATABASE_URL: ENC[AES256_GCM,data:Sa7M3LBnrVUqKI6AM2EAy/S10IbwK6o9tNG6OF1NCGesBVpMUjpOSzrz7XJjIo6H6Joqksf6XZTCL1LYrk4/9a2xrchGGa+15yKnEhLzZLCJJHqYGBA=,iv:0Xs8R5xAShqJM97LEPBqMe3C4uor/4Is8hvYdLBU4YQ=,tag:DIsalNc0LPFsrkzEO+0LtA==,type:str]
-    INIT_POSTGRES_USER: ENC[AES256_GCM,data:XVSDIS6TvA==,iv:JQ7GZMHvyjkbbtMTv4wASHNsw5r/DpvaWqfUN6pNIi4=,tag:gVt7tcO87EmqRAdzIkHDJw==,type:str]
-    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:T4iTgkCJKTQd1mU2Hw==,iv:4z/fcsL8lKREfMMU6cXBc9/Xgn0EV3Kp0eb2rBbMcXY=,tag:wZKchTF/G/kswQcPmMazvw==,type:str]
-    SMTP_FROM_EMAIL: ENC[AES256_GCM,data:upRQlnbA7W1+xUV9v2ksCA==,iv:v6J0a4Su526b5cUmAUwUsZDZ8ZtC03O6VskZJfWeKTo=,tag:j4iyx3+GYvbXOXSM4uI6lA==,type:str]
-    SMTP_FROM_PASSWORD: ENC[AES256_GCM,data:/ttEHqhevg==,iv:dR/uxepplCTvrbCuKpuQSMFai4BF4pBDzc/bVSiM9CY=,tag:DVU3Im7Ti5jQV4aip8a3yA==,type:str]
-    LOG_LEVEL: ENC[AES256_GCM,data:0E9xI70=,iv:7Yx7U1gfECJcWWfrRm0p8uZkozeBmP4WxpRrrVv2YKY=,tag:kAxPJL21wPoP6xj5iYYxug==,type:str]
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:5WC+bSXZsp+6xr7D98o7Eo4=,iv:BfL/8qlDQCp2uLC2x6XbogJwRVkAdI7yvvVHBhh5Qto=,tag:tE5gpiQG69RSZz8UJCpttA==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:8b/UsN7imx4nYSa7JUkKxndCUik=,iv:ZrDqXxYuRRZuyW1Tlf+0L9rTzwJhPUR6WEWsbTEIN9Q=,tag:9ndGTum3CSweqEpTdoQAyQ==,type:str]
+    SECRET_KEY: ENC[AES256_GCM,data:jTOKhBLCT+GYcDqMDhRK32345iXTr3QyLEu2qviy11/MREDfgkdpxRK+ovhy5kYX9uqyZFaes3rM/HofeJNYxQ==,iv:pJADPgolAdh0LBVIGYSBP6gmRsUay2M58d34evoKJok=,tag:OeJkS7G6QL5IfLbrPBGkBQ==,type:str]
+    UTILS_SECRET: ENC[AES256_GCM,data:Rf7FVozZfPqRAwBt9gz1AdiPFKrBcX6EAyHl8Wdl8BViqQPq6K9MhNP+Ec1JdjuLTNDLvdFzl3vFOrMMqqLUWw==,iv:PxLD7onkoLu+8bCNHfmnVcnOQYmV36BQWhh504JLejI=,tag:6habz4XwJcsABkm+dCab9Q==,type:str]
+    DATABASE_URL: ENC[AES256_GCM,data:FoeLA1YIHMZmcbgr2tvR/ouRx7kLQFBR0fvDDOUDgzqfp57YQcuMyc2fgWMZd1zVARm1v6bYhX3yOTC7xAurbpdYwvaQ70lWfEOAXtSt0xYvLXqqklU=,iv:new3wOFOxJbaBHRsNPszfItttPo8fMXWcpplxvNqbeQ=,tag:u6V9jUqoT2DIvagJ8d8vYw==,type:str]
+    INIT_POSTGRES_USER: ENC[AES256_GCM,data:vAgzl60FAQ==,iv:AvMjZD94cgmtt+u5l/T4uJaqXwLYMyIp9K0bslh6VsQ=,tag:ava7kEb4yJPUDGHmU/HT5A==,type:str]
+    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:1FbRVhf9eWyI1jmJ7Q==,iv:vz3G7qLs81RjlxgYx35hf0a+2AlJANoKSKXFyL9ENAg=,tag:5VCBhuV83IPiBK9+ZoPhrw==,type:str]
+    LOG_LEVEL: ENC[AES256_GCM,data:Yrylt+U=,iv:ndeYhR3tnXPvx6C/qXO+TaKUWK0bWKgJLMl2mOl16Dw=,tag:AH4H06SyWXh1W6kEbMcRRw==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -25,14 +23,14 @@ sops:
         - recipient: age1rr569v9jm7ck70q4wpnspfhdvt4y5m6s604tx0ygs0a65qkt7g4qdszk6k
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDRi9uMEdrRzRiVUNkbnBW
-            T0lSblRkLzhHUHJldzkyV2d6VEtOdm1XR2xvCkhVc1h5cnlibVk2c3RMWWNzd2Nn
-            U05RSkxoazE2U1NPTjZxYjFyVk5Pcm8KLS0tIHd4ejJzUExhQXUwUE9JUmRxbkxh
-            SFhkdG9Sb2FaeWdjdktFdVlHTHNBMEUK1BuHNee1jgdylOeZM1enCfZ2WpnRvoiF
-            AEMa04QDThib5kPMlO3okc2huGf4CGf/+JUCDm+rjoadZvRu065CbA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOYjdNTkNxS0Y4cW9wRWEw
+            anRhRW9TNzNOSVp2bUpoT0pJaU13RTdvNlJvCkhpNTBhN1VJWUdpcE5rSElmSEVl
+            OTZkbEJvVGlwWTNaMmFhbDFNbU9qN1EKLS0tIHp2aHJRYmNYTFdpV1V4OXVsN2M5
+            c0QvTEhFd0F6QkQzRlVSMjUvakNpbEEKvebAY+1abhClaB7iUniU/94X8LWXVsqu
+            AozHUmNta/PD2SWHb+vceCy/I9lWltpP1+ISNkxzE2fuPaZwLz6zZw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-01-30T17:08:49Z"
-    mac: ENC[AES256_GCM,data:oZO/LkSCyy5X6AaIVLfNWsFm1BaqJoRdfwzQuA5QBJj9Pa2N6/gz3j1JFLSs+VjRxbPVrrLQA1Yaf5WcLkPG8PTQh0QI/Wsfkk+O8ODHcpe5p4C1V6yHVMovGa9GQEvs0e4HLCKwyK/Ykmmmk636WN8DY8Kb4UfbrTXwEFBRSXc=,iv:Oc9ukLlbDbm1zFUc3hMjym78rfC1Qdjgc5AargxATDI=,tag:YZShSDOsJUUgDNYYN5FFHw==,type:str]
+    lastmodified: "2026-08-08T16:47:18Z"
+    mac: ENC[AES256_GCM,data:f8jB2S3hHZ3jGjQgls/LVORZNsHJp9siJEvsupOG1f+0UfzTZprt/93dmb4jIzdnSYCvpxIwFWMNGs4IJJ2t5JUYmYk8WUtqQY1Z4iLI/zGPzAx5mxclV9k/Pzi/gMPZRwD8wZU23tcICkO6zITShfYGJzVSWcJcv8uLCI+TLko=,iv:PzB6cnzbcRYK/clH6D2HcsctNJjFGaP0qgPnAx9VOps=,tag:vsfy2SkcVjilOU2iuYd67A==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.1


### PR DESCRIPTION
## Summary

- **Root cause of stuck consent screen:** The `cluster-media-outline` Flux Kustomization was failing to build due to an undefined variable `${SECRET_SMTP_HOST_GMAIL}` in `env.yaml`. This silently blocked **every** outline change since commit `49be2e9c` — including the `offline_access` scope removal that was meant to suppress the OIDC consent screen. The live StatefulSet still had `OIDC_SCOPES=openid profile email offline_access`, and per OIDC spec, `offline_access` forces a consent prompt even under `consent_mode: implicit`.
- **Fix:** Replace undefined `${SECRET_SMTP_HOST_GMAIL}` with the correctly-defined `${SECRET_SMTP_HOST}`, and wire all remaining SMTP env vars (`PORT`, `USERNAME`, `PASSWORD`, `FROM_EMAIL`, `FROM_NAME`) to the `SECRET_SMTP_*` family (all verified defined in `kubernetes/flux/vars/secret.sops.yaml`).
- **Secret cleanup:** Removed dead `SMTP_FROM_EMAIL` and `SMTP_FROM_PASSWORD` keys from the outline secret (`SMTP_FROM_PASSWORD` was never a valid Outline env var; `SMTP_FROM_EMAIL` is now provided via the env patch).

Once merged, Flux will reconcile successfully, the `offline_access` removal (commit `49be2e9c`) will finally be applied, and the consent screen should be suppressed.

## Test plan
- [ ] `flux reconcile ks cluster-media-outline -n flux-system --with-source` succeeds (no envsubst error)
- [ ] Outline pods restart with `OIDC_SCOPES=openid profile email` (no `offline_access`)
- [ ] OIDC login flow no longer shows a consent screen
- [ ] SMTP email sending works (invite emails, etc.)

## Notes
- The `redirect to bare thekao.cloud` concern could not be reproduced — all configured URLs point to `w.thekao.cloud`. The bare `thekao.cloud` redirect was likely a side effect of the broken `offline_access` consent flow dropping the OIDC return path, causing Authelia to fall back to its `default_redirection_url`.