### PR TITLE
feat(llmsafespaces): bump to v0.13.0

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.12.1"
+        tag: "0.13.0"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.12.1"
+        tag: "0.13.0"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -132,7 +132,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.12.1"
+            tag: "0.13.0"
       freeModelsRefresher:
         enabled: false
 
@@ -203,7 +203,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.12.1"
+        tag: "0.13.0"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -222,7 +222,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.12.1"
+          tag: "0.13.0"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.12.1
+    tag: v0.13.0
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
## Summary

Bumps LLMSafeSpaces from v0.11.0 to v0.13.0 — rolls the GitRepository tag and all five image tags (api, controller, frontend, relay-router, base) atomically per the established pattern.

## Release: [v0.13.0](https://github.com/lenaxia/LLMSafeSpaces/releases/tag/v0.13.0)

### Added
- **Session contract + V2 session queue (#695)** — platform-owned session contract behind a single adapter seam, V2 session queue (US-63.1→63.4)
- **SSE bridge + stranded-input recovery (#698)** — US-63.5 SSE bridge for reliable streaming, US-63.9 stranded-input recovery

### Fixed
- **Trigger concurrent-fire race (#700)** — `ClaimDueCronTriggers` with `FOR UPDATE SKIP LOCKED` + atomic timestamp advance prevents multi-replica duplicate fires that inflated the failure counter past `auto_disable_after`
- **Trigger counter reset on re-enable (#700)** — `UpdateTrigger` now resets `consecutive_failures` on `enabled=false→true` transition
- **Workspace re-suspend during activation (#696)** — `K8sWorkspaceActivator` refreshes `last-activity-at` annotation on activation, preventing the controller idle-timeout from immediately re-suspending
- **Stuck-Creating escape hatch + FailedMount auto-recovery (#702)** — `spec.suspend=true` now honored in Pending/Creating; FN3b recovery guard fixed for FailedMount pods
- **Trigger editor routine parity (#694)** — full editing controls for routine triggers
- **Mobile-responsive drill-down navigation (#693)**

## Changes

- `kubernetes/flux/repositories/git/llmsafespaces.yaml` — `ref.tag: v0.11.0` → `v0.13.0`
- `kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml` — 5× `image.tag: "0.11.0"` → `"0.13.0"` (api, controller, relay-router, frontend, base runtime)