### PR TITLE
feat(llmsafespaces): bump to v0.13.1

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.12.2"
+        tag: "0.13.1"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.12.2"
+        tag: "0.13.1"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -132,7 +132,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.12.2"
+            tag: "0.13.1"
       freeModelsRefresher:
         enabled: false
 
@@ -203,7 +203,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.12.2"
+        tag: "0.13.1"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -222,7 +222,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.12.2"
+          tag: "0.13.1"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.12.2
+    tag: v0.13.1
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
## Summary

Bumps LLMSafeSpaces from v0.12.2 to v0.13.1 — rolls the GitRepository tag and all five image tags (api, controller, frontend, relay-router, base) atomically.

This release includes v0.13.0 (skipped in talos-ops-prod due to premature bump + rollback) and v0.13.1.

## Release: [v0.13.1](https://github.com/lenaxia/LLMSafeSpaces/releases/tag/v0.13.1)

### Fixed
- **Session origin recording for routine triggers (#706)** — routine sessions now show the purple "routine" badge in the sidebar and link back to their trigger. The `session_origins` table and `RecordSessionOrigin` store method were built during Epic 64 but never wired into the engine.
- **Create forms moved to detail pane (#705)**

## Also includes v0.13.0

### Added
- Session contract + V2 session queue (#695)
- SSE bridge + stranded-input recovery (#698)
- Fresh-load queue visibility (#701)

### Fixed
- Trigger concurrent-fire race (#700)
- Trigger counter reset on re-enable (#700)
- Workspace re-suspend during activation (#696)
- Stuck-Creating escape hatch + FailedMount auto-recovery (#702)