### PR TITLE
feat(llmsafespaces): bump to v0.14.1

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.14.0"
+        tag: "0.14.1"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.14.0"
+        tag: "0.14.1"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -132,7 +132,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.14.0"
+            tag: "0.14.1"
       freeModelsRefresher:
         enabled: false
 
@@ -203,7 +203,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.14.0"
+        tag: "0.14.1"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -222,7 +222,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.14.0"
+          tag: "0.14.1"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.14.0
+    tag: v0.14.1
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
## Summary

Bumps LLMSafeSpaces to **v0.14.1** — the Sev1 hotfix for the 0.14.0 GetHistory 502 ([#730](https://github.com/lenaxia/LLMSafeSpaces/issues/730)/[#731](https://github.com/lenaxia/LLMSafeSpaces/pull/731)).

opencode 1.18.10's flat-string tool shape + per-message decode resilience. Restores session history for all users/workspaces. Production is currently on 0.13.1 (rolled back); 0.14.1 forward-fixes and also restores the dev-preview tunnel + MCP-port fix from 0.14.0.

## Changes

- `helm-release.yaml`: 5 image tags `0.14.0 → 0.14.1` (api, controller, relay-router, relay-proxy, frontend)
- `llmsafespaces.yaml`: Flux GitRepository ref `v0.14.0 → v0.14.1`

## Merge gate

**Do not merge until the v0.14.1 release pipeline finishes** and images are pushed to ghcr.io — otherwise Flux will hit ImagePullBackOff. Tracking: https://github.com/lenaxia/LLMSafeSpaces/actions/runs/31470296287

Release notes: https://github.com/lenaxia/LLMSafeSpaces/releases/tag/v0.14.1