### PR TITLE
chore(ai): sync to ai-workflows@v0.2.9

### DIFF
--- a/.github/workflows/ai-comment.yml
+++ b/.github/workflows/ai-comment.yml
@@ -51,8 +51,8 @@ jobs:
       (github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'COLLABORATOR')
-    uses: lenaxia/ai-workflows/.github/workflows/ai-comment.yml@v0.2.7
+    uses: lenaxia/ai-workflows/.github/workflows/ai-comment.yml@v0.2.9
     secrets: inherit
     with:
-      version: v0.2.0
+      version: v0.2.9
       project_name: talos-ops-prod

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -23,8 +23,8 @@ permissions:
 
 jobs:
   respond:
-    uses: lenaxia/ai-workflows/.github/workflows/issue-opened.yml@v0.2.7
+    uses: lenaxia/ai-workflows/.github/workflows/issue-opened.yml@v0.2.9
     secrets: inherit
     with:
-      version: v0.2.0
+      version: v0.2.9
       project_name: talos-ops-prod

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -22,8 +22,8 @@ jobs:
   review:
     # Skip renovate[bot] PRs — handled by renovate-analysis.yml
     if: github.event.pull_request.user.login != 'renovate[bot]'
-    uses: lenaxia/ai-workflows/.github/workflows/pr-review.yml@v0.2.7
+    uses: lenaxia/ai-workflows/.github/workflows/pr-review.yml@v0.2.9
     secrets: inherit
     with:
-      version: v0.2.0
+      version: v0.2.9
       project_name: talos-ops-prod


### PR DESCRIPTION
Manual sync from lenaxia/ai-workflows@v0.2.9.

propagate.yml computed this bump but could not open a cross-repo PR (AI_WORKFLOWS_PAT not set). PR opened manually.

## What's in v0.2.9

- **PR #30** — Skip automation-bots (renovate, github-actions, release-please, dependabot, mergify, github-merge-queue) in the reusable pr-review.yml. Bot PRs now skip cleanly instead of failing with `permission: none`.
- Reverts PR #28 (dead TOKEN env workaround). Verified the opencode CLI's assertPermissions doesn't honor the legacy skip path.

## Diff

Bumps the three caller workflow files (`issue-opened.yml`, `pr-review.yml`, `ai-comment.yml`) from their current pin to `@v0.2.9`. No source/prompt changes (those are forked/consumer-owned).