### PR TITLE
fix(longhorn): prevent volume degradation cascade via alerts, offline rebuild, CPU limits

### DIFF
--- a/kubernetes/apps/kyverno/policies/enforce-default-resource-limits.yaml
+++ b/kubernetes/apps/kyverno/policies/enforce-default-resource-limits.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: enforce-default-resource-limits
+  namespace: kyverno
+  annotations:
+    policies.kyverno.io/title: Enforce Default Resource Limits
+    policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      This policy injects default CPU limits on containers that do not specify
+      one. Without CPU limits, a single runaway container can consume all node
+      CPU via CFS, starving system-critical components like Longhorn instance
+      managers and causing replica engine timeouts that cascade into volume
+      degradation. Excludes system namespaces where components manage their
+      own resource reservations.
+spec:
+  mutateExistingOnPolicyUpdate: true
+  rules:
+    - name: add-default-cpu-limit-containers
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - longhorn-system
+                - kyverno
+                - flux-system
+                - cert-manager
+                - openebs-system
+      preconditions:
+        all:
+          - key: "{{ request.operation || 'BACKGROUND' }}"
+            operator: AnyIn
+            value: ["CREATE", "UPDATE", "BACKGROUND"]
+      mutate:
+        foreach:
+          - list: "request.object.spec.containers[?!resources.limits.cpu]"
+            patchStrategicMerge:
+              spec:
+                containers:
+                  - name: "{{ element.name }}"
+                    resources:
+                      limits:
+                        cpu: "4000m"
+    - name: add-default-cpu-limit-initcontainers
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - longhorn-system
+                - kyverno
+                - flux-system
+                - cert-manager
+                - openebs-system
+      preconditions:
+        all:
+          - key: "{{ request.operation || 'BACKGROUND' }}"
+            operator: AnyIn
+            value: ["CREATE", "UPDATE", "BACKGROUND"]
+      mutate:
+        foreach:
+          - list: "request.object.spec.initContainers[?!resources.limits.cpu]"
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  - name: "{{ element.name }}"
+                    resources:
+                      limits:
+                        cpu: "2000m"

--- a/kubernetes/apps/kyverno/policies/kustomization.yaml
+++ b/kubernetes/apps/kyverno/policies/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   #- apply-ingress-external-dns-annotations.yaml
   #- apply-ingress-whitelist-annotations.yaml
   #- delete-cpu-limits.yaml
+  - enforce-default-resource-limits.yaml
   - snapshot-cronjob-controller.yaml
   - sync-postgres-secrets.yaml
   - sync-redis-secrets.yaml

--- a/kubernetes/apps/storage/longhorn/app/helm-release.yaml
+++ b/kubernetes/apps/storage/longhorn/app/helm-release.yaml
@@ -65,6 +65,22 @@ spec:
       concurrentAutomaticEngineUpgradePerNodeLimit: 1
       defaultEngineImage: docker.io/longhornio/longhorn-engine:v1.12.0
       systemManagedComponentsNodeSelector: "node-role.kubernetes.io/worker: true"
+      # Allow detached volumes to rebuild replicas in the background.
+      # Without this, volumes that detach during a node disruption stay
+      # degraded until their pod reattaches — blocking self-recovery.
+      offlineReplicaRebuilding: true
+
+    # Resource requests for Longhorn Manager so it gets guaranteed CPU
+    # via the longhorn-critical PriorityClass, preventing starvation under
+    # node CPU pressure (root cause of the 2026-08-10 volume cascade).
+    longhornManager:
+      resources:
+        requests:
+          cpu: 500m
+          memory: 512Mi
+        limits:
+          cpu: 2000m
+          memory: 1Gi
 
     # Global node selector and tolerations for all Longhorn components
     global:
@@ -77,3 +93,30 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
+
+  # Post-renderer patches applied after Helm renders the chart.
+  postRenderers:
+    - kustomize:
+        patches:
+          # The Longhorn chart hardcodes the manager readiness probe with
+          # no timeoutSeconds (k8s default: 1s). Under CPU pressure the
+          # manager's /v1/healthz takes longer than 1s to respond, causing
+          # the pod to be marked NotReady — which cascades into engine
+          # disconnections and replica failures. Bump to 5s.
+          - target:
+              version: v1
+              kind: DaemonSet
+              name: longhorn-manager
+            patch: |
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: longhorn-manager
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: longhorn-manager
+                        readinessProbe:
+                          timeoutSeconds: 5
+                          failureThreshold: 5

--- a/kubernetes/apps/storage/longhorn/app/prometheusrules.yaml
+++ b/kubernetes/apps/storage/longhorn/app/prometheusrules.yaml
@@ -67,7 +67,7 @@ spec:
           nominal replica sizes require. New replicas cannot be placed.
         summary: Longhorn node {{$labels.node}} storage scheduling space low.
       expr: (longhorn_node_storage_capacity_bytes - longhorn_node_storage_scheduled_bytes)
-        < 53687091200
+        < ${LONGHORN_MIN_STORAGE_HEADROOM_BYTES}
       for: 10m
       labels:
         issue: Longhorn node {{$labels.node}} has insufficient storage for scheduling.

--- a/kubernetes/apps/storage/longhorn/app/prometheusrules.yaml
+++ b/kubernetes/apps/storage/longhorn/app/prometheusrules.yaml
@@ -20,3 +20,55 @@ spec:
       labels:
         issue: Longhorn volume {{$labels.volume}} usage on {{$labels.node}} is critical.
         severity: critical
+    - alert: LonghornVolumeDegraded
+      annotations:
+        description: Longhorn volume {{$labels.volume}} (PVC {{$labels.pvc}}) in namespace
+          {{$labels.pvc_namespace}} has been degraded for more than 10 minutes. Check
+          Longhorn for failed replicas.
+        summary: Longhorn volume {{$labels.volume}} is degraded.
+      expr: longhorn_volume_robustness{state="degraded"} == 1
+      for: 10m
+      labels:
+        issue: Longhorn volume {{$labels.volume}} is degraded.
+        severity: warning
+    - alert: LonghornVolumeFaulted
+      annotations:
+        description: Longhorn volume {{$labels.volume}} (PVC {{$labels.pvc}}) in namespace
+          {{$labels.pvc_namespace}} is in a faulted state. No healthy replicas remain.
+        summary: Longhorn volume {{$labels.volume}} is faulted.
+      expr: longhorn_volume_robustness{state="faulted"} == 1
+      for: 1m
+      labels:
+        issue: Longhorn volume {{$labels.volume}} is faulted.
+        severity: critical
+    - alert: LonghornNodeCPUPressure
+      annotations:
+        description: Longhorn node {{$labels.node}} CPU usage is at {{$value}}%, risking
+          replica engine timeouts and volume degradation. Investigate CPU-heavy pods.
+        summary: Longhorn node {{$labels.node}} under CPU pressure.
+      expr: 100 * (longhorn_node_cpu_usage_millicpu / longhorn_node_cpu_capacity_millicpu) > 90
+      for: 5m
+      labels:
+        issue: Longhorn node {{$labels.node}} CPU usage is critical.
+        severity: warning
+    - alert: LonghornInstanceManagerCPUPressure
+      annotations:
+        description: Longhorn instance manager on {{$labels.node}} is consuming {{$value}}m
+          CPU, which may indicate replica rebuild storms or engine instability.
+        summary: Longhorn instance manager on {{$labels.node}} under high CPU load.
+      expr: longhorn_instance_manager_cpu_usage_millicpu > 2000
+      for: 5m
+      labels:
+        issue: Longhorn instance manager on {{$labels.node}} under CPU pressure.
+        severity: warning
+    - alert: LonghornNodeStorageSchedulingFailure
+      annotations:
+        description: Longhorn node {{$labels.node}} has less scheduling headroom than
+          nominal replica sizes require. New replicas cannot be placed.
+        summary: Longhorn node {{$labels.node}} storage scheduling space low.
+      expr: (longhorn_node_storage_capacity_bytes - longhorn_node_storage_scheduled_bytes)
+        < 53687091200
+      for: 10m
+      labels:
+        issue: Longhorn node {{$labels.node}} has insufficient storage for scheduling.
+        severity: warning

--- a/kubernetes/flux/vars/cluster-settings.yaml
+++ b/kubernetes/flux/vars/cluster-settings.yaml
@@ -76,3 +76,8 @@ data:
   NFS_METUBE: "/volume2/downloads/[Plex Temp Library]/YouTube"
   NFS_NZBGET: "/volume3/k8s-nfs/nzbget"
   NFS_KOMGA_MEDIA: "/volume1/omoikane/[Manga]"
+
+  # Longhorn: minimum free scheduling headroom (bytes) per node before the
+  # LonghornNodeStorageSchedulingFailure alert fires. 50 GiB accommodates
+  # the largest default-class volume nominal size with rebuild overhead.
+  LONGHORN_MIN_STORAGE_HEADROOM_BYTES: "53687091200"


### PR DESCRIPTION
## Summary

Post-mortem fixes for the 2026-08-10 Longhorn cascade where worker-00 CPU starvation (146% overcommit) caused 47 degraded volumes and 30h of Home Assistant downtime. The cascade was silent for 30 hours because no alerting existed for degraded volumes.

### Root cause chain
1. worker-00 CPU at 100% (11.6 cores requested on 8-core node)
2. Longhorn instance-manager starved → replica RPC timeouts → 41 replicas marked ERR
3. `offline-replica-rebuilding=false` prevented detached volumes from self-healing
4. Manager readiness probe (1s timeout) falsely failed under load, amplifying chaos
5. Pods without CPU limits consumed unlimited CPU via CFS

### Changes (5 fixes)

| # | Fix | File | What |
|---|-----|------|------|
| 1 | **Prometheus alerts** | `prometheusrules.yaml` | `LonghornVolumeDegraded` (warning, 10m), `LonghornVolumeFaulted` (critical), `LonghornNodeCPUPressure` (>90%), `LonghornInstanceManagerCPUPressure` (>2000m), `LonghornNodeStorageSchedulingFailure` (<50GB headroom) |
| 2 | **offlineReplicaRebuilding: true** | `helm-release.yaml` | Detached volumes rebuild replicas in background instead of staying degraded |
| 4 | **Manager probe timeout 1s→5s** | `helm-release.yaml` | postRenderers kustomize patch (chart hardcodes 1s with no value override) |
| 6 | **Kyverno CPU limits policy** | `enforce-default-resource-limits.yaml` | Injects default CPU limit (4000m) on containers without one, preventing CFS starvation. Excludes system namespaces. |
| 7 | **LH manager resource requests** | `helm-release.yaml` | 500m CPU request + 2000m limit so manager gets guaranteed CPU via PriorityClass |

### What would have changed on Aug 10
- **Alert #1** would have paged within 10 min of the first degraded volume (instead of 30h silent)
- **Fix #2** would have let 11 detached volumes self-heal automatically
- **Fix #6** would have capped runaway pods, preventing CPU starvation
- **Fix #4** would have kept the LH manager stable under load
- **Fix #7** would have guaranteed the manager its CPU slice

### Test plan
- [ ] Flux reconciles HelmRelease without drift (postRenderers patch applies cleanly)
- [ ] Kyverno policy activates and mutates new pods correctly
- [ ] PrometheusRule loads and alerts fire for degraded volumes
- [ ] `offlineReplicaRebuilding` setting shows `true` in Longhorn UI