### PR TITLE
chore(bump): LLMSafeSpaces v0.14.2

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.14.1"
+        tag: "0.14.2"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.14.1"
+        tag: "0.14.2"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -132,7 +132,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.14.1"
+            tag: "0.14.2"
       freeModelsRefresher:
         enabled: false
 
@@ -203,7 +203,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.14.1"
+        tag: "0.14.2"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -222,7 +222,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.14.1"
+          tag: "0.14.2"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.14.1
+    tag: v0.14.2
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
## Summary

Bumps LLMSafeSpaces to **v0.14.2** — Epic 63 (Inboard Session Queue) complete.

- Chart GitRepository ref: `v0.14.1` → `v0.14.2`
- 5 image tags (api, controller, relay-router, frontend, runtime-base): `0.14.1` → `0.14.2`

### What changed upstream

The external Redis-backed message queue (`api/internal/services/msgqueue/`) is deleted. The proxy now uses opencode's V2 session API exclusively. Net: −4,458 lines. Abort is now non-destructive (queued messages survive). The `LLMSAFESPACE_V2_SESSION_QUEUE` feature flag is removed.

Release: https://github.com/lenaxia/LLMSafeSpaces/releases/tag/v0.14.2