### PR TITLE
fix(kopia): reduce snapshot job TTL from 24h to 10m to free volume refs

### DIFF
--- a/kubernetes/apps/kyverno/policies/snapshot-cronjob-controller.yaml
+++ b/kubernetes/apps/kyverno/policies/snapshot-cronjob-controller.yaml
@@ -63,12 +63,16 @@ spec:
             schedule: "0 12 * * *"
             suspend: false
             concurrencyPolicy: Forbid
-            successfulJobsHistoryLimit: 1
-            failedJobsHistoryLimit: 2
+            successfulJobsHistoryLimit: 0
+            failedJobsHistoryLimit: 1
             jobTemplate:
               spec:
-                # Keep at least one job in completed state in accordance to the schedule
-                ttlSecondsAfterFinished: 86400
+                # Clean up completed jobs quickly (10 min). Snapshot jobs mount
+                # live RWO PVCs — completed pods hold volume attachment refs that
+                # block Longhorn detach/rebuild operations. The snapshot data is
+                # already in kopia's repository; we only need the pod long enough
+                # to finish and inspect logs on failure.
+                ttlSecondsAfterFinished: 600
                 template:
                   spec:
                     automountServiceAccountToken: false


### PR DESCRIPTION
## Summary

Completed Kopia snapshot jobs mount live RWO PVCs and hold volume attachment references for their entire lifetime. With the previous `ttlSecondsAfterFinished=86400` (24h), completed snapshot pods blocked Longhorn detach/rebuild operations — causing volumes to get stuck in `attaching` state during the 2026-08-11 LH recovery.

### Changes
- `ttlSecondsAfterFinished`: 86400 → **600** (10 min, enough for log review)
- `successfulJobsHistoryLimit`: 1 → **0** (kopia tracks snapshot history in its repository; k8s Job objects are not needed)
- `failedJobsHistoryLimit`: 2 → **1** (keep one failure for debugging)

### Why this matters
Each snapshot CronJob pod mounts its PVC directly (RWO, co-located with the app pod via podAffinity). A completed pod in `Succeeded` phase still holds a `VolumeAttachment`, which Longhorn interprets as an active workload. This prevents LH from:
- Detaching the volume for node maintenance
- Rebuilding replicas (volume won't detach cleanly)
- Processing `offlineReplicaRebuilding` (LH sees a "workload" and tries to attach)

With a 10-minute TTL, the Job pod is cleaned up shortly after the snapshot completes, releasing the volume reference immediately.