### PR TITLE
chore(bump): LLMSafeSpaces v0.14.3

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.14.2"
+        tag: "0.14.3"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.14.2"
+        tag: "0.14.3"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -132,7 +132,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.14.2"
+            tag: "0.14.3"
       freeModelsRefresher:
         enabled: false
 
@@ -203,7 +203,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.14.2"
+        tag: "0.14.3"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -222,7 +222,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.14.2"
+          tag: "0.14.3"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.14.2
+    tag: v0.14.3
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
## Summary

Bump LLMSafeSpaces from v0.14.2 → **v0.14.3**.

### What's in v0.14.3

Epic 65 adapter migration hotfixes — fixes the session history 502s, broken context usage indicator, and several opencode 1.18.10 wire-shape drift bugs:

- **#739:** Per-session context usage (`context_used`) backfill from CRD after API pod restarts
- **#740:** Adapter cross-cutting regressions — restored metering, quota enforcement, session limits, workspace readiness checks to all adapter handler paths
- **Finding O:** `ParseSessionWire`/`ParseSessionListWire` deterministic 502 on opencode 1.18.10 (Summary/Cost/Time shape drift) — the root cause of the "response interrupted" symptom
- **#743:** `providerID` silently dropped, `Agent` field missing, `Status` latent 502
- **#744:** V2 bridge spurious wake on busy sessions + in-memory TTL leak
- **#735:** Epoch-millis timestamp parsing
- **#736:** `CreatedAt` omitempty

### Changes

- `helm-release.yaml`: 5 image tags (api, controller, relay-router, frontend, runtime) `0.14.2` → `0.14.3`
- `llmsafespaces.yaml` (Flux GitRepository): `tag: v0.14.2` → `tag: v0.14.3`

Release: https://github.com/lenaxia/LLMSafeSpaces/releases/tag/v0.14.3