### PR TITLE
chore(bump): LLMSafeSpaces v0.14.4

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.14.3"
+        tag: "0.14.4"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.14.3"
+        tag: "0.14.4"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -132,7 +132,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.14.3"
+            tag: "0.14.4"
       freeModelsRefresher:
         enabled: false
 
@@ -203,7 +203,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.14.3"
+        tag: "0.14.4"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -222,7 +222,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.14.3"
+          tag: "0.14.4"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.14.3
+    tag: v0.14.4
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
## Summary

Bump LLMSafeSpaces from v0.14.3 → **v0.14.4**.

### What's in v0.14.4

Epic 65 full regression audit — 15 issues resolved. Headline fix: **#755 Sev1** (messages disappear on send).

- **#755 Sev1:** V2 queue prompts never drained on opencode 1.18.10 — switched to synchronous V1 Send
- **#737:** GetHistory 502 on sessions >16MB — streaming JSON decoder
- **#750:** Reasoning content silently dropped on 1.18.10
- **#746:** Adapter 10s HTTP timeout broke long LLM turns
- **#745:** CapDiff falsely advertised (filediff never wired)
- **#751:** SSE tracker billing drift + memory leak + data race
- **#753:** Secrets rotation could restart mid-turn (status enum mismatch)
- **#749:** MCP tools OOM risk (unbounded body read)
- **#747:** agentd parser drift (silent zero-return, no body cap)
- **#754:** session_index channel drops silently
- **#743/#744/#740/#739:** Wire-shape drift, V2 bridge, cross-cutting regressions, context backfill

### Changes

- `helm-release.yaml`: 5 image tags `0.14.3` → `0.14.4`
- `llmsafespaces.yaml` (Flux GitRepository): `tag: v0.14.3` → `tag: v0.14.4`

Release: https://github.com/lenaxia/LLMSafeSpaces/releases/tag/v0.14.4