### PR TITLE
bump: llmsafespaces v0.13.1 → v0.15.2

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.13.1"
+        tag: "0.15.2"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.13.1"
+        tag: "0.15.2"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -132,7 +132,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.13.1"
+            tag: "0.15.2"
       freeModelsRefresher:
         enabled: false
 
@@ -203,7 +203,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.13.1"
+        tag: "0.15.2"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -222,7 +222,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.13.1"
+          tag: "0.15.2"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.13.1
+    tag: v0.15.2
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
## Summary

First production bump since v0.13.1. Bundles all Epic 65 adapter migration hotfixes plus the full verification marathon from worklog 0744.

### What changed (user-facing)

| Symptom | Fix | Release |
|---|---|---|
| Messages disappear after send | V1 synchronous send (#755) | v0.15.0 |
| History 502 on large sessions | Streaming decoder (#737) | v0.15.0 |
| Null history crash on new sessions | nil→[] guard | v0.15.0 |
| Sessions stuck "busy" forever | statusz ground-truth (#792) | v0.15.0 |
| Abort/Stop button does nothing | V1 /abort — V2 interrupt removed in 1.18.10 (#801) | v0.15.1 |
| Frontend crash on empty bodies | text() guard (#782) | v0.15.2 |
| Stale sessions accumulate | prune from fillGaps ticker (#792 S8) | v0.15.2 |

### Verification

- opencode source diff (v1.15.12 vs v1.18.10) confirms v2/ route group deleted
- Live pod verification: V1 send/abort work, V2 endpoints return fake success
- Full API stack test with real auth: 10.8MB history 200, empty session `[]`, send/abort/delete all 200
- 60s+ LLM turn: 200 in 79s
- 6 PRs merged with TDD regression tests (all verified to fail on revert)
- Contract tests pinning opencode 1.18.10 wire shapes

### Files changed

- `kubernetes/flux/repositories/git/llmsafespaces.yaml`: GitRepository tag v0.13.1 → v0.15.2
- `kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml`: 5 image tags 0.13.1 → 0.15.2