### PR TITLE
bump: llmsafespaces v0.15.2 → v0.15.3

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.15.2"
+        tag: "0.15.3"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.15.2"
+        tag: "0.15.3"
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -132,7 +132,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.15.2"
+            tag: "0.15.3"
       freeModelsRefresher:
         enabled: false
 
@@ -203,7 +203,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.15.2"
+        tag: "0.15.3"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -222,7 +222,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.15.2"
+          tag: "0.15.3"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.15.2
+    tag: v0.15.3
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
Critical: SSE scanner buffer fix (64KB→16MB). TRUE root cause of stuck-busy and missing messages.