### PR TITLE
feat(cloudflare): edge uptime monitor with Alertmanager/Pushover alerts

### DIFF
--- a/ansible/playbooks/site.yaml
+++ b/ansible/playbooks/site.yaml
@@ -16,3 +16,11 @@
     - role: kiosk
       tags: [kiosk]
       when: "'kiosk' in group_names"
+
+- name: Deploy Cloudflare workers (uptime monitor)
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+    - role: cloudflare
+      tags: [cloudflare]

--- a/ansible/roles/cloudflare/defaults/main.yaml
+++ b/ansible/roles/cloudflare/defaults/main.yaml
@@ -1,0 +1,35 @@
+---
+# Cloudflare Workers deployed via REST API (no wrangler/node needed).
+#
+# Required vars (supply via the CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID
+# keys in the home/ansible-runner secret — "UNSET" placeholders ship by
+# default and the role skips gracefully until they are filled in):
+#   cf_api_token:  API token with Workers Scripts:Edit + Workers KV Storage:Edit
+#   cf_account_id: Cloudflare account ID
+
+cf_api_token: UNSET
+cf_account_id: UNSET
+
+cf_worker_name: uptime-monitor
+cf_worker_script: uptime-monitor.js
+cf_worker_compat_date: "2026-08-01"
+cf_worker_cron: "*/5 * * * *"
+
+cf_worker_kv_title: uptime-monitor-state
+
+# Endpoints probed from the Cloudflare edge (external path only — this is
+# what split-horizon DNS hides from internal monitoring)
+cf_worker_endpoints:
+  - https://authelia.thekao.cloud
+  - https://s3.thekao.cloud
+  - https://alerts.thekao.cloud
+  - https://grafana.thekao.cloud
+  - https://git.thekao.cloud
+  - https://photos.thekao.cloud
+
+# Alertmanager push endpoint (no-auth ingress); alerts route to pushover
+# via severity=critical
+cf_worker_alertmanager_url: https://alerts.thekao.cloud
+cf_worker_alertname: ExternalEndpointDown
+
+cf_api_base: https://api.cloudflare.com/client/v4

--- a/ansible/roles/cloudflare/defaults/main.yaml
+++ b/ansible/roles/cloudflare/defaults/main.yaml
@@ -17,19 +17,26 @@ cf_worker_cron: "*/5 * * * *"
 
 cf_worker_kv_title: uptime-monitor-state
 
+# Base domain for monitored endpoints. Kept as a single variable because
+# Flux postBuild substitution (${VAR}) only applies to manifests under
+# kubernetes/ — ansible files are never processed by envsubst, so a literal
+# ${SECRET_DEV_DOMAIN} here would be pushed to Cloudflare unresolved.
+# Keep this in sync with the cluster-settings SECRET_DEV_DOMAIN equivalent.
+cf_worker_domain: thekao.cloud
+
 # Endpoints probed from the Cloudflare edge (external path only — this is
 # what split-horizon DNS hides from internal monitoring)
 cf_worker_endpoints:
-  - https://authelia.thekao.cloud
-  - https://s3.thekao.cloud
-  - https://alerts.thekao.cloud
-  - https://grafana.thekao.cloud
-  - https://git.thekao.cloud
-  - https://photos.thekao.cloud
+  - "https://authelia.{{ cf_worker_domain }}"
+  - "https://s3.{{ cf_worker_domain }}"
+  - "https://alerts.{{ cf_worker_domain }}"
+  - "https://grafana.{{ cf_worker_domain }}"
+  - "https://git.{{ cf_worker_domain }}"
+  - "https://photos.{{ cf_worker_domain }}"
 
 # Alertmanager push endpoint (no-auth ingress); alerts route to pushover
 # via severity=critical
-cf_worker_alertmanager_url: https://alerts.thekao.cloud
+cf_worker_alertmanager_url: "https://alerts.{{ cf_worker_domain }}"
 cf_worker_alertname: ExternalEndpointDown
 
 cf_api_base: https://api.cloudflare.com/client/v4

--- a/ansible/roles/cloudflare/files/uptime-monitor.js
+++ b/ansible/roles/cloudflare/files/uptime-monitor.js
@@ -1,0 +1,158 @@
+/**
+ * Uptime Monitor — Cloudflare Worker (ES module)
+ *
+ * Runs on Cloudflare's edge on a cron schedule and probes public endpoints
+ * from OUTSIDE the LAN. This catches external-path failures that split-horizon
+ * DNS hides from internal monitoring (WAN down, Cloudflare issues, broken
+ * port-forwards, expired certs).
+ *
+ * State transitions are tracked in a KV namespace. On up->down a firing alert
+ * is pushed to Prometheus Alertmanager (/api/v2/alerts); on down->up the same
+ * alert (matched by labels) is pushed as resolved. Alertmanager routes to the
+ * existing pushover receiver via severity=critical.
+ *
+ * Firing alerts carry endsAt = now + 10m and are re-posted every run, so if
+ * this worker dies, the alerts auto-resolve instead of paging forever.
+ *
+ * Bindings (set by the ansible cloudflare role):
+ *   - UPTIME_KV:            KV namespace (required) — per-endpoint state
+ *   - UPTIME_ENDPOINTS:     plain_text — comma-separated URLs to probe
+ *   - ALERTMANAGER_URL:     plain_text — e.g. https://alerts.thekao.cloud
+ *   - ALERTMANAGER_ALERTNAME (optional, default ExternalEndpointDown)
+ */
+
+const DEFAULT_TIMEOUT_MS = 15000;
+const FIRING_TTL_MS = 10 * 60 * 1000; // must exceed the cron interval
+const USER_AGENT = "uptime-monitor-worker/1.0";
+
+export default {
+  async scheduled(event, env) {
+    const endpoints = splitEndpoints(env.UPTIME_ENDPOINTS);
+    const alertmanager = (env.ALERTMANAGER_URL || "").replace(/\/+$/, "");
+    const alertname = env.ALERTMANAGER_ALERTNAME || "ExternalEndpointDown";
+
+    if (endpoints.length === 0) {
+      console.log("UPTIME_ENDPOINTS not set; nothing to probe");
+      return;
+    }
+
+    const results = await Promise.all(endpoints.map((url) => probe(url)));
+    const down = results.filter((r) => !r.ok);
+    console.log(
+      JSON.stringify({ total: results.length, up: results.length - down.length, down: down.length })
+    );
+
+    const alerts = [];
+
+    for (const r of results) {
+      const prev = await env.UPTIME_KV.get(stateKey(r.url));
+      const wasDown = prev === "down";
+      const isDown = !r.ok;
+
+      if (isDown) {
+        // new outage or still down: push/refresh a firing alert (endsAt keeps
+        // it alive between runs; Alertmanager dedupes by label set)
+        alerts.push({
+          labels: {
+            alertname,
+            severity: "critical",
+            instance: r.url,
+            source: "cloudflare-worker",
+          },
+          annotations: {
+            summary: `External endpoint down: ${r.url}`,
+            description: `Probe from Cloudflare edge failed: ${
+              r.error || `HTTP ${r.status}`
+            }`,
+          },
+          startsAt: new Date().toISOString(),
+          endsAt: new Date(Date.now() + FIRING_TTL_MS).toISOString(),
+          generatorURL: r.url,
+        });
+      } else if (wasDown) {
+        // recovered: same labels with endsAt in the past resolves the alert
+        alerts.push({
+          labels: {
+            alertname,
+            severity: "critical",
+            instance: r.url,
+            source: "cloudflare-worker",
+          },
+          annotations: {
+            summary: `External endpoint recovered: ${r.url}`,
+          },
+          startsAt: new Date().toISOString(),
+          endsAt: new Date().toISOString(), // resolved
+          generatorURL: r.url,
+        });
+      }
+
+      await env.UPTIME_KV.put(stateKey(r.url), isDown ? "down" : "up");
+    }
+
+    if (alerts.length > 0) {
+      if (!alertmanager) {
+        console.error("Transitions detected but ALERTMANAGER_URL not set");
+      } else {
+        const rc = await pushAlerts(alertmanager, alerts);
+        console.log(`Alertmanager accepted ${alerts.length} alert(s): HTTP ${rc}`);
+      }
+    }
+  },
+
+  // Manual trigger for testing: curl the worker URL (workers.dev disabled by
+  // default; enable temporarily or use `wrangler dev` / the dashboard)
+  async fetch(request, env) {
+    const endpoints = splitEndpoints(env.UPTIME_ENDPOINTS);
+    const results = await Promise.all(endpoints.map((url) => probe(url)));
+    return new Response(JSON.stringify(results, null, 2), {
+      headers: { "content-type": "application/json" },
+    });
+  },
+};
+
+function splitEndpoints(raw) {
+  return (raw || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function stateKey(url) {
+  return `state:${url}`;
+}
+
+async function probe(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      redirect: "follow",
+      headers: { "User-Agent": USER_AGENT },
+      signal: controller.signal,
+      cf: { cacheTtl: 0 }, // never serve probe responses from CF cache
+    });
+    // 2xx/3xx = healthy; 401/403 from forward-auth gates still proves the
+    // external path (DNS + WAN + Traefik + cert) is alive
+    return { url, ok: res.status < 500, status: res.status };
+  } catch (err) {
+    return { url, ok: false, status: null, error: err.message };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function pushAlerts(alertmanager, alerts) {
+  try {
+    const res = await fetch(`${alertmanager}/api/v2/alerts`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(alerts),
+    });
+    return res.status;
+  } catch (err) {
+    console.error(`Alertmanager push failed: ${err.message}`);
+    return null;
+  }
+}

--- a/ansible/roles/cloudflare/tasks/main.yaml
+++ b/ansible/roles/cloudflare/tasks/main.yaml
@@ -1,0 +1,137 @@
+---
+# Deploy the uptime-monitor Cloudflare Worker via REST API.
+# Runs on localhost (connection: local) — no fleet host required.
+#
+# Skips with a message when cf_api_token/cf_account_id are not provided,
+# so the ansible-runner stays green until the secret keys are populated.
+
+- name: Check Cloudflare credentials are configured
+  ansible.builtin.set_fact:
+    cf_configured: "{{ (cf_api_token | default('UNSET') not in ('', 'UNSET')) and (cf_account_id | default('UNSET') not in ('', 'UNSET')) | ternary('true', 'false') }}"
+
+- name: Skip Cloudflare worker deployment (no credentials)
+  ansible.builtin.debug:
+    msg: >-
+      cf_api_token/cf_account_id not set — populate CLOUDFLARE_API_TOKEN and
+      CLOUDFLARE_ACCOUNT_ID in the home/ansible-runner secret to enable.
+  when: not cf_configured | bool
+
+- name: Verify Cloudflare API credentials
+  ansible.builtin.uri:
+    url: "{{ cf_api_base }}/user/tokens/verify"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ cf_api_token }}"
+    status_code: 200
+  register: cf_verify
+  when: cf_configured | bool
+  changed_when: false
+
+- name: Find existing KV namespace
+  ansible.builtin.uri:
+    url: "{{ cf_api_base }}/accounts/{{ cf_account_id }}/storage/kv/namespaces?per_page=100"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ cf_api_token }}"
+    status_code: 200
+  register: cf_kv_list
+  when: cf_configured | bool
+  changed_when: false
+
+- name: Set KV namespace ID if it exists
+  ansible.builtin.set_fact:
+    cf_kv_id: "{{ (cf_kv_list.json.result | selectattr('title', 'equalto', cf_worker_kv_title) | map(attribute='id') | first) | default('') }}"
+  when: cf_configured | bool
+
+- name: Create KV namespace
+  ansible.builtin.uri:
+    url: "{{ cf_api_base }}/accounts/{{ cf_account_id }}/storage/kv/namespaces"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ cf_api_token }}"
+    body_format: json
+    body:
+      title: "{{ cf_worker_kv_title }}"
+    status_code: 200
+  register: cf_kv_create
+  when:
+    - cf_configured | bool
+    - cf_kv_id | length == 0
+
+- name: Set KV namespace ID after creation
+  ansible.builtin.set_fact:
+    cf_kv_id: "{{ cf_kv_create.json.result.id }}"
+  when:
+    - cf_configured | bool
+    - cf_kv_id | length == 0
+
+- name: Build worker metadata (bindings)
+  ansible.builtin.set_fact:
+    cf_worker_metadata:
+      main_module: "{{ cf_worker_script }}"
+      compatibility_date: "{{ cf_worker_compat_date }}"
+      workers_dev: false
+      bindings:
+        - type: kv_namespace
+          name: UPTIME_KV
+          namespace_id: "{{ cf_kv_id }}"
+        - type: plain_text
+          name: UPTIME_ENDPOINTS
+          text: "{{ cf_worker_endpoints | join(',') }}"
+        - type: plain_text
+          name: ALERTMANAGER_URL
+          text: "{{ cf_worker_alertmanager_url }}"
+        - type: plain_text
+          name: ALERTMANAGER_ALERTNAME
+          text: "{{ cf_worker_alertname }}"
+  when: cf_configured | bool
+
+- name: Stage metadata and script for upload
+  ansible.builtin.copy:
+    content: "{{ cf_worker_metadata | to_nice_json }}"
+    dest: /tmp/cf-worker-metadata.json
+    mode: "0600"
+  when: cf_configured | bool
+  changed_when: false
+
+- name: Upload worker script (multipart metadata + module)
+  # curl is used because the metadata part requires an explicit
+  # application/json content type alongside the module file part
+  ansible.builtin.command:
+    argv:
+      - curl
+      - -sS
+      - -f
+      - -X
+      - PUT
+      - -H
+      - "Authorization: Bearer {{ cf_api_token }}"
+      - -F
+      - metadata=@/tmp/cf-worker-metadata.json;type=application/json
+      - -F
+      - "module=@{{ role_path }}/files/{{ cf_worker_script }};type=application/javascript+module"
+      - "{{ cf_api_base }}/accounts/{{ cf_account_id }}/workers/scripts/{{ cf_worker_name }}"
+  register: cf_upload
+  when: cf_configured | bool
+  changed_when: cf_upload.rc == 0
+  no_log: true
+
+- name: Set cron trigger schedule
+  ansible.builtin.uri:
+    url: "{{ cf_api_base }}/accounts/{{ cf_account_id }}/workers/scripts/{{ cf_worker_name }}/schedules"
+    method: PUT
+    headers:
+      Authorization: "Bearer {{ cf_api_token }}"
+    body_format: json
+    body:
+      - cron: "{{ cf_worker_cron }}"
+    status_code: 200
+  when: cf_configured | bool
+  changed_when: false
+
+- name: Clean up staged metadata
+  ansible.builtin.file:
+    path: /tmp/cf-worker-metadata.json
+    state: absent
+  when: cf_configured | bool
+  changed_when: false

--- a/kubernetes/apps/home/ansible-runner/app/configmap.yaml
+++ b/kubernetes/apps/home/ansible-runner/app/configmap.yaml
@@ -48,10 +48,14 @@ data:
     # Install collections from repo requirements
     ansible-galaxy collection install -r /workspace/ansible/requirements.yml
 
-    # Run ansible
+    # Run ansible (pass Cloudflare creds through when present)
     echo "=== Running ansible ==="
+    CF_ARGS=""
+    if [ -n "$${CLOUDFLARE_API_TOKEN:-}" ]; then
+      CF_ARGS="--extra-vars cf_api_token=$${CLOUDFLARE_API_TOKEN} cf_account_id=$${CLOUDFLARE_ACCOUNT_ID:-}"
+    fi
     cd /workspace/ansible
-    ansible-playbook "playbooks/$${PLAYBOOK}" -i inventory/hosts.yaml --extra-vars "ansible_ssh_common_args='-o StrictHostKeyChecking=no -o ConnectTimeout=10'"
+    ansible-playbook "playbooks/$${PLAYBOOK}" -i inventory/hosts.yaml $${CF_ARGS} --extra-vars "ansible_ssh_common_args='-o StrictHostKeyChecking=no -o ConnectTimeout=10'"
 
     echo "=== Done ==="
 

--- a/kubernetes/apps/home/ansible-runner/app/job.yaml
+++ b/kubernetes/apps/home/ansible-runner/app/job.yaml
@@ -5,12 +5,12 @@ metadata:
   name: ansible-runner
   namespace: home
   annotations:
-    ansible.talos-ops/revision: "343814f4"
+    ansible.talos-ops/revision: "73c48deb"
 spec:
   template:
     metadata:
       annotations:
-        ansible.talos-ops/revision: "343814f4"
+        ansible.talos-ops/revision: "73c48deb"
     spec:
       restartPolicy: Never
       activeDeadlineSeconds: 600

--- a/kubernetes/apps/home/ansible-runner/app/job.yaml
+++ b/kubernetes/apps/home/ansible-runner/app/job.yaml
@@ -5,12 +5,12 @@ metadata:
   name: ansible-runner
   namespace: home
   annotations:
-    ansible.talos-ops/revision: "2850eef7"
+    ansible.talos-ops/revision: "343814f4"
 spec:
   template:
     metadata:
       annotations:
-        ansible.talos-ops/revision: "2850eef7"
+        ansible.talos-ops/revision: "343814f4"
     spec:
       restartPolicy: Never
       activeDeadlineSeconds: 600
@@ -19,6 +19,19 @@ spec:
           image: python:3.12-slim
           workingDir: /workspace
           command: ["/bin/bash", "/scripts/entrypoint.sh"]
+          env:
+            - name: CLOUDFLARE_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: ansible-runner
+                  key: CLOUDFLARE_API_TOKEN
+                  optional: true
+            - name: CLOUDFLARE_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: ansible-runner
+                  key: CLOUDFLARE_ACCOUNT_ID
+                  optional: true
           volumeMounts:
             - name: scripts
               mountPath: /scripts

--- a/kubernetes/apps/home/ansible-runner/app/secret.sops.yaml
+++ b/kubernetes/apps/home/ansible-runner/app/secret.sops.yaml
@@ -4,7 +4,9 @@ metadata:
     name: ansible-runner
     namespace: home
 stringData:
-    SSH_PRIVATE_KEY: ENC[AES256_GCM,data:hTSJEu8JzLf6COoQj9TJ6D3IMlS6Wxv0TUm1oG1GTPV0aIJIr7xE3370Vx+1OVIYftWG4Hf3la4tCdJECzJI29xB+g5csaT1X6KxKm810dNws4kCKk6zyduziBJHTuUrheRZxv30mau8S2R5ehnTfuRPqa7i81QVq+Y/mZIJyoPL9AojZTpP1dND01iYBVzOZVq4Fjsr8ZUTH+hIvaBJ7A2j5RiM0CiTX3P9AuJQ20a0XYWcg/47n0PEnVPVov/aQPOlH7/kwAASciFvP2gfPKjqoosUDYPNp6+J0PShFutr7r57wyo6EohDF2wy/g/JuYa+Wre7mEiaIEaBS4qfEiU0d7FYI7fOsR670VTc36jcPg5D5PZJvO8VouvWmbQB+yFiKArHqurBQzZZz9dAb1MaOfUTVWsKAeiKdXlPEvTqoT5sskq+fW5mP0RA4wRn6jjCenGZUak54YvfhNeuPrajhJKNfuXbnKRqUrP/w6vSawtB7AfHQYCu7ojddJcnF3ZICg3P4NVKzQsPja/lUVtUKkfnfKi+DMZt,iv:u7/pf5qm68rfJkUPEBHM8MOeyLoDL6k9FfqNEcYEN9M=,tag:XMJTfWaaeUZCnWvww9z5vw==,type:str]
+    CLOUDFLARE_API_TOKEN: ENC[AES256_GCM,data:tK9AXz0=,iv:UUI6rFkmCb8I94JprnzgLRaLaTTucnwJnphqUg55VNc=,tag:H64k0wrH9rYXvcVNS58Mxg==,type:str]
+    CLOUDFLARE_ACCOUNT_ID: ENC[AES256_GCM,data:uztGmiM=,iv:WVJGj8MItgeBJbxkxRx/pqR+HsQBYDx0C1YwYuxiHTA=,tag:Ylz/R7uTyG1BDuAKu8nb8A==,type:str]
+    SSH_PRIVATE_KEY: ENC[AES256_GCM,data:o3kC1Q1nOT6o54zj+DQ9t0oG1R8N94ZcbTjV5iwWp18r/NgFkutEOOrHgbIvGUPxk63lkZLrZHzCDgogctNLNhffd3D/m7IY39rcWQxe0MkWoMnbhqUOqpXUcj6SpUEfs0yiJds7+8MzfLrmkFwhjib5IXcqlKrubG02ELnMAZNlS2YwrAevZjz1mogdsMuK8vwG9Qq4gKw84lp5mFd3L7nCmolaxYpTSD/6ufxSBvIsaI3xhEcbpp/c/gpB21G/T0cueUdGFGLM3gfrRqqS6MloWx1435uFz6/7s8+T193oR2ycD1NrmWkOnUO2rcGPOsRzDGO+oN4a+tS7WEAiCQMacY+4ScGC6TcI1zcJ+N7XyxLgFyjjP4YKai2k9qPUNU7YJMuMCHWW4JLhsBlYRuaTFiGYf0rIUy50hvWUEBBHBVXru5bTdQ6+LUFz+guC6RDTbxtPMSCK64WdhfDx0kcQzgsqKfqy3UgAff5WeikiGN4rYLKxqXNXNY0wsY3+IiTWsJu8FHTXc3BvdFvyUvFQIxcxRPApb8QN,iv:WtU0eeXnfj+PJ2JYY2PbOAHQVo+C2ssfMaS/ZLwAuE4=,tag:0FrlzYMsxNjkLPIca4TxDg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -14,14 +16,14 @@ sops:
         - recipient: age1rr569v9jm7ck70q4wpnspfhdvt4y5m6s604tx0ygs0a65qkt7g4qdszk6k
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIbFBmR1hiNmIzbTJFSWl1
-            K1hCYjFCYnp5Q1V5N0pTcktjVGhidWhyMFhjClpLNjJEY3lSVmhUV09Qd2dVaGFh
-            ZXI3OThHU2s1K3BNTXBNenJ4MStuZ00KLS0tIGIyWTM4MDBlempsV2wvM1BiY1Rs
-            WmtHOXhqNTBzMkllU3JuNWFzMFNmRzQKg7Igm0tKSSpzYjhQHg1NpItkSN2Z+MO+
-            VUqvHbonyOtSbCMHezQnyMglQnl3e6cPLBTizVOUOR0gNDqkhmhh9w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvMVdSNVZzKzNXZ0JiTkdu
+            aXV6dDFxczczTnlmVzVNeVpjejJNcDZGajJjCjBUWkJQS2dSMklvcHVpQVN4dGNN
+            WFRPbEtCZmxIWVZsdEpaaExSUWk3T2sKLS0tIHdZOHdURkxzZm5RV005OXBVVFc4
+            WUdIbjVRakVGU2hCeTVxUWtIU1BLaFUKdwP2ENrzhJwF5dKHXSa19aY9WacPu1Z4
+            9uSa130G5KXMWQ2ueiLlU9g5rU1pk6wtpvlFkJLXpPPHmImYGBrtYQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-31T06:18:46Z"
-    mac: ENC[AES256_GCM,data:Oj3JlR66VIU9UUQYid/XpPXsa6KRLcyQT3zhSkcmJfnSioW8o7XGUHJwr+uGpMmdHQD/Vq+1/KqZAAdD7B/F0cfEStTYGkaUaalX92UB4e1cK3wLjGYNsMDNUOk6CLFjvAQ0EPVMmZe+79ki2h9uVxxwuR4qCFGW2IspuGv5zXY=,iv:kdnOJV1/JfqPHdufZG1QlGZz6C1Fvwrprbi5cECyLE0=,tag:JfPGXBQl4iYWuCsQ/AZN3w==,type:str]
+    lastmodified: "2026-08-14T15:35:48Z"
+    mac: ENC[AES256_GCM,data:asFnsQRx9nTs3c1nwxtc5t0tT4d3VyBXLynfuGq5yv1Y/W/FQ8ZX0qzmEEianTiCVoSaAFDiIU5XoKjGjHnivLztG31C+g236XeZEjNigiKdMcMvT93/u7g2Ixm2Nv9niDV/d6dztNm5JCtO4RjyNekpGSiqFJCh7ly7/dYS/HM=,iv:CQAu1rTOY97fWmb8o4oIJBHh82IkvEwMH29+zQhZpVs=,tag:GXfWxqvpXcPs2d0RUvkyng==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.1


### PR DESCRIPTION
## Summary

Adds a Cloudflare Worker that probes public endpoints from the edge every 5 minutes and pushes alerts to Alertmanager on outage — covering the external-path failures (WAN down, broken port-forwards, expired certs, upstream DNS) that split-horizon DNS now hides from internal monitoring.

## How it works

**Worker** (`ansible/roles/cloudflare/files/uptime-monitor.js`):
- Probes each endpoint with GET (2xx–4xx = alive; a 401 from forward-auth still proves DNS + WAN + Traefik + cert are up)
- Tracks per-endpoint state in a KV namespace
- On down: POSTs `severity=critical` alert to `alerts.thekao.cloud/api/v2/alerts` → routed to the existing **pushover** receiver
- On recovery: POSTs the same labels with `endsAt` in the past → Alertmanager resolves it
- Firing alerts carry a 10-minute `endsAt` heartbeat refreshed each run — if the worker itself dies, alerts auto-resolve instead of paging forever

**Deployment** (`ansible/roles/cloudflare/`) — no wrangler, no node, no new deployment channel:
- Runs as a `localhost` play in `site.yaml`, same as the rest of the fleet
- Ensures the KV namespace exists, uploads the module via multipart REST (metadata + bindings), sets the cron schedule
- Skips gracefully while credentials are `UNSET` so GitOps runs stay green

**Credentials**: optional `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` keys added to the existing ansible-runner secret (sops, `UNSET` placeholders). Token needs `Workers Scripts:Edit` + `Workers KV Storage:Edit`. Fill them in to activate.

## Monitored endpoints (configurable in role defaults)

authelia, s3, alerts, grafana, git, photos (.thekao.cloud)

## Validation

- 7/7 playbooks pass syntax check
- site.yaml --list-tasks resolves the new localhost play
- worker JS passes node --check
- secret re-encrypted and decrypt-verified (4 encrypted values)

## Notes

- Alertmanager ingress is deliberately no-auth (existing `networking-chain-no-auth` middleware); no new exposure added
- Alert `group_by` (alertname, namespace) consolidates multiple simultaneous outages into one Pushover notification