### PR TITLE
fix(external-dns): move Cloudflare token to sops secret

### DIFF
--- a/kubernetes/apps/networking/external-dns/app/helm-release.yaml
+++ b/kubernetes/apps/networking/external-dns/app/helm-release.yaml
@@ -35,7 +35,10 @@ spec:
 
     env:
       - name: CF_API_TOKEN
-        value: ${SECRET_CLOUDFLARE_TOKEN}
+        valueFrom:
+          secretKeyRef:
+            name: external-dns
+            key: CF_API_TOKEN
 
     policy: sync
 

--- a/kubernetes/apps/networking/external-dns/app/kustomization.yaml
+++ b/kubernetes/apps/networking/external-dns/app/kustomization.yaml
@@ -4,4 +4,5 @@ commonLabels:
   app.kubernetes.io/name: &app external-dns
   app.kubernetes.io/instance: *app
 resources:
+  - secret.sops.yaml
   - helm-release.yaml

--- a/kubernetes/apps/networking/external-dns/app/secret.sops.yaml
+++ b/kubernetes/apps/networking/external-dns/app/secret.sops.yaml
@@ -1,14 +1,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: cloudflare-creds
+    name: external-dns
     namespace: networking
-    labels:
-        app.kubernetes.io/name: external-dns
-        app.kubernetes.io/instance: external-dns
-type: Opaque
 stringData:
-    api-token: ENC[AES256_GCM,data:UGhFg3A4C6eAQ101sn7v8vuOfuJqBbxLXPI=,iv:i0/lpkLO6Urqc/BE4LS7V6nWDLrnnESw9VtLPy8xI1g=,tag:GaF7uocQQ62uPazR75yBiQ==,type:str]
+    CF_API_TOKEN: ENC[AES256_GCM,data:09EKjFaE+cWuGgbd4omDG/ol1h7vV89/8Bbtd2hEBloCFkDPccMpUg==,iv:SOTTGbqr3v6ADpVu13GdJ+2GAwksQi90aNkrnI9MR28=,tag:EEdpwC1R+eHbfy6Ro1ofGQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -18,14 +14,14 @@ sops:
         - recipient: age1rr569v9jm7ck70q4wpnspfhdvt4y5m6s604tx0ygs0a65qkt7g4qdszk6k
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYQmJzNWdjTUFYcEFneUJi
-            RVZ5aVhYeWp4QVJ2cmlxK0NnVjRkejV1TGlNCldLR1k0eFlUdVZnRll1KzNqOVdP
-            ZVJkUitXcTZnK0tYejJqOG1NeitNbjAKLS0tIEFtYWxpcHV4all1aFJwUEpEUFRh
-            emFScmlJYi9ncjU5S3FQMGQxSHRLMEUKLYkck67Qq33Ce9guDFJm4uOfAXsY0cVJ
-            kO67N7qMU5Qfgu8baAu76Mj6C9E2c8zCGVg5SvH2bRulnsSwxT9nYw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQOHdkV1pVNXVCK241WTYw
+            SFp0SUJ2bWk3cW1XbXlTZUNCdDE3ZHFFendBClVCbHhPdVdvMG05NTlnVy9GbDUy
+            L1BtS1Z1TUo2Umx6Y1B5RnM1eXJESnMKLS0tIFJ0bWM0R0E1NUx3WlBkd0RtbDBo
+            RUE1MjdRditndGs5V2dBZlRIeHFCZHcK4/6URkjnvfib9Bbi4/2gP42tZ1EfivUq
+            lPeTBCtDHxJhKSW/EJvYgpyeto1XQOCSrcAvfDCNV1J62RbmVqDQVg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-08-20T16:33:19Z"
-    mac: ENC[AES256_GCM,data:xw38+qlVfyr0Qf4T+/9yzN2YqWMxU6GFkeCyL98GWvPz22sNmTwDNwbaZZs1Jc/YEcxUB4WXpweeOi2vB+hu1FNqmV89aWFW7hb8wZbz/2mQvwc4ojUojQx1cdUDcxUgXwr/cAmeo3bV+oEEsMgLjzsDx69uzBs8i65eHMcq9DE=,iv:0J1wbvUPGFLO3HY2XUefYu/ZW/HuCJ2f/NGtAE4E9bk=,tag:3yGCMuL2ztsZgQQ0KI10TA==,type:str]
+    lastmodified: "2026-08-14T15:59:45Z"
+    mac: ENC[AES256_GCM,data:z3UZsE2nlR67SVBtA2nDqSqSzDG3C6zoi+lW4lC2z8V5WpM6H0feqxTbjMATfUaPH9x0jtZQPWgeQlZxm7mwHX8gmJxdnLKvKipdPShADfN/UYXjwcAD6o6YNB3Gj6/Fk7wt2yvYRjRvGwfeRTkeQWEIYz2bzos9CaxrGAeKYiA=,iv:4nfp1X26hR1U+ExwnvNpMjvH4Bg9iaBEa5iKeEVtjJQ=,tag:Gi486FqVeM5Mu7lGZRbJ0Q==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.1


### PR DESCRIPTION
## Summary

The external-dns Cloudflare token was injected as a plain `env[].value` (Flux-substituted from cluster-secrets), leaving the resolved token readable in the deployment spec to anyone with pod read access (e.g. `kubectl get deploy -n networking external-dns -o yaml`).

## Changes

- New sops-encrypted secret `networking/external-dns` with `CF_API_TOKEN` (same pattern as `cert-manager/cloudflare-api-token`)
- helm-release env switched to `valueFrom.secretKeyRef`
- Token value unchanged — copied from the running deployment at encrypt time, no rotation needed (was never in git)

## Validation

- Secret decrypts and passes kubectl dry-run
- kustomize build OK

## Note

${SECRET_CLOUDFLARE_TOKEN} remains in cluster-secrets for any other consumers; this scopes the DNS token exposure to secret-readers only.