### PR TITLE
fix(kyverno): drop mutateExistingOnPolicyUpdate from enforce-default-resource-limits

### DIFF
--- a/kubernetes/apps/kyverno/policies/enforce-default-resource-limits.yaml
+++ b/kubernetes/apps/kyverno/policies/enforce-default-resource-limits.yaml
@@ -16,7 +16,6 @@ metadata:
       degradation. Excludes system namespaces where components manage their
       own resource reservations.
 spec:
-  mutateExistingOnPolicyUpdate: true
   rules:
     - name: add-default-cpu-limit-containers
       match:


### PR DESCRIPTION
## Summary

`enforce-default-resource-limits` has never been admitted — Kyverno's validate-policy webhook rejects it with `rules[N].mutate.targets has to be specified when mutateExistingOnPolicyUpdate is set` (the rules use `mutate.foreach` without targets), leaving `cluster-kyverno-policies` in permanent ReconciliationFailed.

## Fix

Drop the flag. Background scans still mutate existing un-limited pods; admission mutates new pods. Only loss: existing already-mutated pods won't re-mutate when the policy's limit values change (they pick it up on pod recreation).

Note: the other two policies with this flag (sync-redis-secrets, apply-ingress-external-dns-annotations) survive because they have no `mutate` rules for the webhook to validate against.

## Validation

`kubectl apply --dry-run=server` now passes (previously denied by the webhook).