### PR TITLE
feat(vllm): upgrade to v0.27.1-cu129, serve Qwen3.8-27B-FP8

### DIFF
--- a/kubernetes/apps/home/localai/vllm/helm-release.yaml
+++ b/kubernetes/apps/home/localai/vllm/helm-release.yaml
@@ -42,16 +42,15 @@ spec:
             image:
               repository: vllm/vllm-openai
               # renovate: depName=vllm/vllm-openai
-              # renovate: ignore
               tag:
-                v0.20.0-cu130-ubuntu2404@sha256:aff65d7198dd284c37dd0a18a606544cc5e92bfb0d5eb608b77e8b8f1c6b8b0d
+                v0.27.1-cu129-ubuntu2404@sha256:0e1ee52750c67718a596ba63176034aa18b439c4a69896ac5a0a8393919aa4df
             command: ["/bin/sh", "-c"]
             args:
               - |
                 vllm serve \
-                    QuantTrio/Qwen3.6-27B-AWQ \
+                    Qwen/Qwen3.8-27B-FP8 \
                     --served-model-name qwen3 \
-                    --dtype half \
+                    --dtype auto \
                     --max-model-len 262144 \
                     --gpu-memory-utilization 0.97 \
                     --tensor-parallel-size 1 \
@@ -64,7 +63,7 @@ spec:
                     --enable-auto-tool-choice \
                     --tool-call-parser qwen3_coder \
                     --reasoning-parser qwen3 \
-                    --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":3}' \
+                    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
                     --default-chat-template-kwargs '{"enable_thinking":false}' \
                     --port 8000
             env:


### PR DESCRIPTION
## Summary

Upgrade the main vLLM deployment (`home/vllm`, 4090 48GB / worker04) to run the new **Qwen3.8-27B** release on vLLM v0.27.1.

| | Before | After |
|---|---|---|
| Image | `v0.20.0-cu130-ubuntu2404` (pinned, renovate-ignored) | `v0.27.1-cu129-ubuntu2404` (digest-pinned) |
| Model | `QuantTrio/Qwen3.6-27B-AWQ` (~15GB AWQ) | `Qwen/Qwen3.8-27B-FP8` (official FP8, ~28GB, incl. `mtp.safetensors`) |
| dtype | `half` | `auto` (FP8 checkpoint → bf16 activations) |
| MTP method | `qwen3_next_mtp` | `mtp` (per official recipe) |

Unchanged: `--served-model-name qwen3` (litellm/open-webui need no changes), 262144 ctx, fp8 KV cache, prefix caching, chunked prefill, `qwen3_coder`/`qwen3` parsers, `enable_thinking:false` default, GPU UUID pinning, resources.

## Why these choices

- **v0.27.1**: official [vLLM recipe](https://recipes.vllm.ai/Qwen/Qwen3.8-27B) target; v0.27.0 landed Qwen3.5-family support + multi-layer MTP speculator; v0.27.1's sole patch is quantized DSpark Markov head support. No cu130 build exists for v0.27.x — cu129 requires driver ≥ 525, and worker04 runs the 580 driver (already runs cu130 images, which is strictly more demanding). Removes the stale `# renovate: ignore` (added in 8ba008e7 pending the driver upgrade, which has since landed).
- **Official FP8 over BF16/community quants**: BF16 (~55GB) doesn't fit 48GB. FP8 (~28GB weights) leaves ~15GB for KV + activations under 0.97 util — enough for a full 262k-token sequence (~8.4GB fp8 KV, hybrid arch: only 16/64 layers are full attention, so KV is cheap). Checkpoint verified: arch `Qwen3_5ForConditionalGeneration` (same family as Qwen3.6), ships `mtp.safetensors`, `quant_method: fp8`.
- **Spec decode `mtp`** (not `qwen3_next_mtp`): per the official recipe for Qwen3.8; the 3.6-specific name came from the QuantTrio model card.

## Memory sanity check (48GB @ 0.97 util ≈ 45GB budget)

- ~28GB weights + ~2GB activations/cudagraphs overhead
- ~15GB KV pool → 1× 262k seq fits comfortably; 3 concurrent max-length seqs (~25GB) would preempt at the extreme (same behavior envelope as the current AWQ config)

## Post-merge checklist

- [ ] First boot: ~28GB model download → expect long probe delay (initialDelaySeconds 600, helm timeout 60m should cover it)
- [ ] PVC `data-vllm` (50Gi): 3.6-AWQ (~16GB) + 3.8-FP8 (~29GB) ≈ 45GB — **prune `QuantTrio/Qwen3.6-27B-AWQ` from the HF cache after cutover**
- [ ] Verify MTP acceptance rate in logs (`accepted speculative tokens`)
- [ ] New Qwen3.8 features available per-request: `reasoning_effort` (xhigh/medium/low), `preserve_thinking`
- [ ] Watch for a QuantTrio Qwen3.8-27B-AWQ (~15GB) as a follow-up if more KV headroom is wanted

## Rollback

Revert this commit — prior state is the proven v0.20.0 + Qwen3.6-AWQ combo, still cached on the PVC.