### PR TITLE
fix(vllm): relax memory config for Qwen3.8-27B-FP8 on 48GB

### DIFF
--- a/kubernetes/apps/home/localai/vllm/helm-release.yaml
+++ b/kubernetes/apps/home/localai/vllm/helm-release.yaml
@@ -51,10 +51,11 @@ spec:
                     Qwen/Qwen3.8-27B-FP8 \
                     --served-model-name qwen3 \
                     --dtype auto \
-                    --max-model-len 262144 \
+                    --max-model-len 131072 \
                     --gpu-memory-utilization 0.97 \
                     --tensor-parallel-size 1 \
-                    --max-num-seqs 3 \
+                    --max-num-seqs 2 \
+                    --limit-mm-per-prompt '{"image":2,"video":1}' \
                     --trust-remote-code \
                     --host 0.0.0.0 \
                     --enable-chunked-prefill \
@@ -71,8 +72,6 @@ spec:
                 value: ${TIMEZONE}
               - name: NVIDIA_VISIBLE_DEVICES
                 value: "GPU-ec4bf65c-4e9e-b857-11e7-bcc716f11d93" # 4090 48GB
-              - name: VLLM_USE_FLASHINFER_SAMPLER
-                value: "1"
               - name: PYTORCH_CUDA_ALLOC_CONF
                 value: "expandable_segments:True,max_split_size_mb:512"
             envFrom:


### PR DESCRIPTION
## Incident

Follow-up to #2241. The Qwen3.8-27B-FP8 deployment came up, served ~30s of traffic (3 successful requests incl. a 300-token MTP generation and a tool call), then the engine died and the pod began crash-looping (`litellm → vllm` connection errors, no recovery for 8+ min with image+weights already cached).

## Diagnosis (behavioral — no cluster access from where this was driven)

The old QuantTrio AWQ checkpoint (~15GB weights) ran the same `gpu-memory-utilization 0.97` with ~13GB more slack than the official FP8 (~28GB incl. MTP head). Remaining headroom on the 48GB 4090 is now consumed by some combination of:

- ViT/multimodal profiling peaks (Qwen3.8 is a native VLM; vLLM profiles worst-case image/video batches — uncapped video profiling is large)
- MTP spec-decode cudagraph capture (draft + target verification graphs)
- long-prefill activation spikes (chunked prefill at 262k max len)

Death right after the first longer prefill shape hit is consistent with an async engine OOM/illegal-access on a lazily-captured path.

## Changes

| Setting | Before | After | Why |
|---|---|---|---|
| `--max-model-len` | 262144 | 131072 | litellm `default` model advertises `max_input_tokens: 32768`; 128k is still 4× that. Halves largest per-seq reservation |
| `--max-num-seqs` | 3 | 2 | Smaller spec-decode verification batches + smaller graph set; returns to the pre-6648f54f concurrency on a tighter memory budget |
| `--limit-mm-per-prompt` | (none) | `image=2 video=1` | Caps multimodal profiling peak — biggest hidden activation reservation for a VLM |
| `VLLM_USE_FLASHINFER_SAMPLER` | `1` | removed | v0.20-era perf flag; on v0.27 the default sampler is fine and this eliminates the flashinfer-sampler × MTP kernel-crash class |

Unchanged: FP8 checkpoint, MTP `mtp` method, fp8 KV cache, prefix caching, parsers, thinking default, 0.97 util.

If this still crash-loops, next lever is dropping `--speculative-config` entirely (MTP off) — noted here so the follow-up is a one-line diff.