### PR TITLE
fix(vllm): disable MTP speculative decode on Qwen3.8-27B-FP8

### DIFF
--- a/kubernetes/apps/home/localai/vllm/helm-release.yaml
+++ b/kubernetes/apps/home/localai/vllm/helm-release.yaml
@@ -64,7 +64,6 @@ spec:
                     --enable-auto-tool-choice \
                     --tool-call-parser qwen3_coder \
                     --reasoning-parser qwen3 \
-                    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
                     --default-chat-template-kwargs '{"enable_thinking":false}' \
                     --port 8000
             env:


### PR DESCRIPTION
Bisect step 2 from #2261. Engine kept dying ~1-2 min after serving start, twice correlated with tool-call requests — memory headroom changes from #2261 did not stop it. Removing MTP spec decode (newest v0.27 code path in play) as the single changed variable. If stable, follow-up bisect can try num_speculative_tokens=1 or prefix-caching-off with MTP re-enabled.