### PR TITLE
fix(vllm): add startup probe, fix rollout race with slow engine boot

### DIFF
--- a/kubernetes/apps/home/localai/vllm/helm-release.yaml
+++ b/kubernetes/apps/home/localai/vllm/helm-release.yaml
@@ -78,6 +78,24 @@ spec:
               - secretRef:
                   name: *appname
             probes:
+              # Qwen3.8-27B-FP8 on the 4090 takes ~8.5 min to reach HTTP-ready
+              # (torch.compile + CUDA graph capture + MTP draft graphs). The old
+              # initialDelaySeconds: 600 on liveness/readiness raced the
+              # Deployment progressDeadlineSeconds: 600 — healthy-but-slow
+              # rollouts were declared Failed and roll-backed (flux flap, which
+              # also GC'd the pods before --previous logs could be captured).
+              # Startup probe owns the slow-boot window (up to 20 min); readiness
+              # and liveness are gated on startup success, so their delays drop.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8000
+                  periodSeconds: 30
+                  failureThreshold: 40
+                  timeoutSeconds: 10
               liveness:
                 enabled: true
                 custom: true
@@ -85,7 +103,7 @@ spec:
                   httpGet:
                     path: /health
                     port: 8000
-                  initialDelaySeconds: 600
+                  initialDelaySeconds: 15
                   periodSeconds: 30
                   successThreshold: 1
                   failureThreshold: 5
@@ -97,7 +115,7 @@ spec:
                   httpGet:
                     path: /health
                     port: 8000
-                  initialDelaySeconds: 600
+                  initialDelaySeconds: 15
                   periodSeconds: 15
                   successThreshold: 1
                   failureThreshold: 5


### PR DESCRIPTION
## Root cause (from in-cluster investigation)

Investigation report: https://paste.thekao.cloud/mike/1267a5aa55444aa2b1b64a9ab587ca77

The two apparent crash-loops after #2241 were **not engine crashes**:

- worker-04 dmesg across both incident windows: zero oom-kills, zero Xid/NVRM errors
- VRAM pinned 46.7/49.1 GiB under worst-case load (2× concurrent fresh ~131k prefills + streaming tool call) — no cliff
- MTP spec decode working well: 54–100% acceptance, mean accepted length 2.6–4.0
- every reproduction attempt passed (tool calls, bursts, vision, near-max prefills)

What actually failed: **rollout race**. The engine takes ~8.5 min to reach HTTP-ready (torch.compile + CUDA graph capture + MTP graphs) while readiness `initialDelaySeconds: 600` matched Deployment `progressDeadlineSeconds: 600` exactly — so a healthy-but-slow pod hit the progress deadline before/at-first-probe and got declared `Failed` → Helm rollback → flap → re-upgrade. Confirmed live at 01:03Z: the "failed" pod had `restartCount: 0` and was answering `/health` 200 when the rollback deleted it. Flaps also GC'd pods, destroying `--previous` logs (why no traceback ever surfaced).

## Fix (one variable: probe timing)

| Probe | Before | After |
|---|---|---|
| startup | none | `/health:8000`, period 30, failureThreshold 40 (20 min budget) |
| liveness | initialDelay 600 | initialDelay 15 (gated on startup success) |
| readiness | initialDelay 600 | initialDelay 15 (gated on startup success) |

## Deliberately not changed

- MTP stays (see #2262 closure — exonerated, measurably helping)
- #2261 memory spec stays (stable throughout the investigation)
- Optional follow-up if flaps ever recur: raise Deployment `progressDeadlineSeconds` beyond 600 (not exposed by app-template values today; would need a rawResources/patch)

## Post-merge verification (external, via litellm relay)

Full functional suite re-run: basic / thinking / tool-call / throughput / vision / stability watch.