### PR TITLE
fix(frigate): switch detector to OpenVINO on iGPU after worker-03 removal

### DIFF
--- a/kubernetes/apps/home/frigate/app/config/config.yml
+++ b/kubernetes/apps/home/frigate/app/config/config.yml
@@ -25,14 +25,11 @@ auth:
   enabled: False
 
 detectors:
-  #  ov:
-  #    type: openvino
-  #    device: GPU
-  #    model:
-  #      path: /openvino-model/ssdlite_mobilenet_v2.xml
-  coral:
-    type: edgetpu
-    device: pci
+  # worker-03 (PCIe Coral) was removed as dead hardware 2026-07-06;
+  # switched to OpenVINO on the Intel iGPU (workers 00/01/02)
+  ov:
+    type: openvino
+    device: GPU
 
 ffmpeg:
   global_args: ["-hide_banner", "-loglevel", "warning"]

--- a/kubernetes/apps/home/frigate/app/helm-release.yaml
+++ b/kubernetes/apps/home/frigate/app/helm-release.yaml
@@ -34,7 +34,6 @@ spec:
   values:
     defaultPodOptions:
       nodeSelector:
-        google.feature.node.kubernetes.io/coral: 'true'
         intel.feature.node.kubernetes.io/gpu: 'true'
       affinity:
         podAntiAffinity:
@@ -151,9 +150,3 @@ spec:
         sizeLimit: 4Gi
         globalMounts:
           - path: /dev/shm
-      coral:
-        type: hostPath
-        hostPath: /dev/apex_0
-        hostPathType: CharDevice
-        globalMounts:
-          - path: /dev/apex_0


### PR DESCRIPTION
## Summary

`frigate-0` has been **Pending 45 days** and the HelmRelease stalled (timeout on StatefulSet InProgress) because its nodeSelector required `google.feature.node.kubernetes.io/coral=true` plus a `/dev/apex_0` hostPath — hardware that lived in **worker-03, drained and deleted as dead hardware on 2026-07-06** (see worklog-20260706). No live node has a Coral; the NFD rule (PCI vendor 1ac1) matches nothing.

## Changes

- `config/config.yml`: enable OpenVINO detector (`type: openvino`, `device: GPU`) — the block was already staged commented-out; remove `coral: edgetpu/pci`
- `helm-release.yaml`: drop the coral nodeSelector term and the apex hostPath persistence block

Frigate 0.17.2 fully supports OpenVINO; workers 00/01/02 carry `intel.feature.node.kubernetes.io/gpu=true`, the i915 resource request and vaapi hwaccel config are already in place and unchanged.

## Risk / follow-up

`LIBVA_DRIVER_NAME=i965` was tuned for worker-03's iGPU; if decode logs show vaapi failures on the new node's GPU generation, flip to the appropriate driver (iHD for 11th-gen+). Detection perf on iGPU is slower than Coral but adequate per owner's call.