### PR TITLE
fix(frigate): drop invalid retain.mode keys rejected by 0.17.2 schema

### DIFF
--- a/kubernetes/apps/home/frigate/app/config/config.yml
+++ b/kubernetes/apps/home/frigate/app/config/config.yml
@@ -48,15 +48,12 @@ record:
   enabled: True
   retain:
     days: 1
-    mode: all
   alerts:
     retain:
       days: 30
-      mode: active_objects
   detections:
     retain:
       days: 30
-      mode: active_objects
 
 objects:
   track:


### PR DESCRIPTION
## Summary

Follow-up to #2265. With frigate-0 finally scheduling, its config validated for the first time in 46 days and failed:

```
Line #49  Key: record -> retain  Value: {'days': 1, 'mode': 'all'}
Message: Extra inputs are not permitted
```

Frigate 0.17.2's schema rejects `mode` under `record.retain` and under `alerts`/`detections` retains. The failed validation drops frigate into **safe mode** (default CPU detector, no cameras) — that's the `CPU detectors are not recommended` warning observed in the logs.

## Changes

Remove the three `mode:` keys (`record.retain.mode: all`, `alerts.retain.mode: active_objects`, `detections.retain.mode: active_objects`). Retention `days` values unchanged.

## Validation

Config validates as YAML; no other `mode:` keys remain in the file. After merge: ConfigMap updates → reloader restarts the pod → full config loads with the OpenVINO detector from #2265.