### PR TITLE
fix(frigate): migrate record retention to 0.17 schema

### DIFF
--- a/kubernetes/apps/home/frigate/app/config/config.yml
+++ b/kubernetes/apps/home/frigate/app/config/config.yml
@@ -46,14 +46,16 @@ snapshots:
 
 record:
   enabled: True
-  retain:
+  continuous:
     days: 1
   alerts:
     retain:
       days: 30
+      mode: active_objects
   detections:
     retain:
       days: 30
+      mode: active_objects
 
 objects:
   track:


### PR DESCRIPTION
## Summary

Second pass at the frigate config validation that forces safe mode. #2266 removed `mode` everywhere, but the 0.17 full reference shows:

- `record.retain` **does not exist** in 0.17 → its `{days: 1, mode: all}` intent maps to `record.continuous.days: 1`
- `mode` **is valid** under `record.alerts.retain` and `record.detections.retain` → #2266's removal there was over-aggressive; restored

## Resulting retention (intent preserved from the original)

| Original (pre-0.17) | Now (0.17) |
|---|---|
| record.retain: 1d, all | record.continuous.days: 1 |
| alerts.retain: 30d, active_objects | unchanged (valid) |
| detections.retain: 30d, active_objects | unchanged (valid) |

## Validation

Diff checked against the verbatim `record:` section of the 0.17 Full Reference Config (keys: enabled, expire_interval, sync_recordings, continuous.days, motion.days, export, preview, alerts.pre/post_capture+retain.days/mode, detections.*)