### PR TITLE
fix(frigate): drop hung reolink_e1_pro, single-camera config

### DIFF
--- a/kubernetes/apps/home/frigate/app/config/config.yml
+++ b/kubernetes/apps/home/frigate/app/config/config.yml
@@ -112,15 +112,14 @@ cameras:
           max_area: 100000
           threshold: 0.7
 
-  reolink_e1_pro:
-    ffmpeg:
-      inputs:
-        - path: rtsp://admin:{FRIGATE_REOLINK_E1_PRO_PASSWORRD}@192.168.0.72:554/h264Preview_01_sub
-          roles:
-            #- detect
-            - rtmp
-              #    detect:
-              #      width: 640
-              #      height: 352
-              #      fps: 7
-              #
+
+  # 2026-08-15 LAN scan: this camera DHCP-drifted from 192.168.0.72 to
+  # 192.168.0.245 (Reolink MAC ec:71:db:15:cb:17) and is hung — answers
+  # ping but no services. Physical power cycle required. Re-enable by
+  # uncommenting and pointing at .245 (or its new lease) when it's back.
+  # reolink_e1_pro:
+  #   ffmpeg:
+  #     inputs:
+  #       - path: rtsp://admin:{FRIGATE_REOLINK_E1_PRO_PASSWORRD}@192.168.0.245:554/h264Preview_01_sub
+  #         roles:
+  #           - detect


### PR DESCRIPTION
## Summary

Closes the frigate crash-loop chain started in #2265/#2266/#2267. After the schema fixes, frigate still crashed at startup: probing the offline `reolink_e1_pro` camera (192.168.0.72) hits an **unfixed 0.17.2 bug** — `asyncio.SubprocessError` doesn't exist (`AttributeError` in `util/services.py:735`), crashing the whole app on any failed ffprobe. Fixed upstream only for the record module (frigate#22393); the services.py instance persists through master.

## LAN scan evidence (arp-scan + nmap -p 554, 192.168.0-4.0/24)

| Device | MAC | State |
|---|---|---|
| 192.168.0.92 (frontdoor) | ec:71:db:68:2e:2a | healthy, RTSP open |
| 192.168.0.245 | ec:71:db:15:cb:17 | hung: ICMP only, zero open ports (top-100 TCP + Reolink UDP 20033/20034/9000) |
| 192.168.0.72 (in config) | — | vacant — the E1 Pro drifted to .245 |

## Changes

- Comment out `reolink_e1_pro` with re-enable notes (point at .245 or its next lease after a physical power cycle)
- Repair file structure: the working-tree copy had become two YAML documents (corrupted during an aborted earlier edit); rewritten as a single valid document, `cameras` = frontdoor only

## Validation

`yaml.safe_load` passes; single document; cameras == [frontdoor]. Expected result after merge: frigate-0 goes Ready, OpenVINO detector loads, frontdoor recording/detection live.