### PR TITLE
fix(frigate): explicit OpenVINO model path

### DIFF
--- a/kubernetes/apps/home/frigate/app/config/config.yml
+++ b/kubernetes/apps/home/frigate/app/config/config.yml
@@ -30,6 +30,8 @@ detectors:
   ov:
     type: openvino
     device: GPU
+    model:
+      path: /openvino-model/ssdlite_mobilenet_v2.xml
 
 ffmpeg:
   global_args: ["-hide_banner", "-loglevel", "warning"]


### PR DESCRIPTION
## Summary

Last blocker in the frigate revival chain (#2265 → #2266 → #2267 → #2268). With the camera fix landed, frontdoor capture starts cleanly, but the OpenVINO detector crashes:

```
frigate/detectors/detection_runners.py:299 __init__
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```

The 0.17.2 OpenVINO plugin passes `model.path` (None when unset) straight to `stat()` — no default fallback. #2265 enabled the staged detector block but dropped the staged `model.path`. This restores it verbatim (`/openvino-model/ssdlite_mobilenet_v2.xml`, the documented default model shipped in the image).

## Validation

Camera pipeline confirmed working in current logs (processor + capture started for frontdoor); this was the only remaining startup error. YAML valid.