### PR TITLE
fix(frigate): startup probe — full-config boot exceeds old liveness budget

### DIFF
--- a/kubernetes/apps/home/frigate/app/helm-release.yaml
+++ b/kubernetes/apps/home/frigate/app/helm-release.yaml
@@ -70,6 +70,9 @@ spec:
                 memory: 2Gi
                 gpu.intel.com/i915: '1'
             probes:
+              # Full-config startup (OpenVINO model load, camera ffprobes,
+              # db vacuum) takes >60s on this hardware; the old 30s+10x3
+              # liveness budget killed nginx before it ever bound :5000.
               liveness: &probes
                 enabled: true
                 custom: true
@@ -77,13 +80,19 @@ spec:
                   httpGet:
                     path: /api/version
                     port: &port 5000
-                  initialDelaySeconds: 30
                   periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
+                  timeoutSeconds: 3
+                  failureThreshold: 5
               readiness: *probes
               startup:
-                enabled: false
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/version
+                    port: *port
+                  periodSeconds: 5
+                  failureThreshold: 36
             securityContext:
               privileged: true
         statefulset:


### PR DESCRIPTION
## Summary

Final blocker in the frigate chain (#2265→#2269). With the full config loading, the app startup (OpenVINO model load + camera ffprobes + db vacuum) takes >60s before nginx binds :5000. The old probe budget (initialDelay 30 + 10s×3 failures) SIGTERMed the container mid-boot:

```
Liveness probe failed: Get http://10.69.8.28:5000/api/version: connection refused
```

Logs show clean shutdown sequences (all s6 services exiting gracefully) — not app crashes. Safe-mode boots were faster, which is why the pod only ever went Ready in safe mode.

## Changes

- Add startup probe: 5s period × 36 failures = 3-minute boot budget
- Liveness/readiness: drop `initialDelaySeconds` (redundant once a startup probe gates it), `timeoutSeconds` 1→3, `failureThreshold` 3→5

## Validation

Camera capture/processor confirmed starting in current logs; nginx bind timing vs old budget confirmed via kubelet events. YAML valid.