### PR TITLE
revert(frigate): restore Coral detector, scale to 0 pending Coral recovery

### DIFF
--- a/kubernetes/apps/home/frigate/app/config/config.yml
+++ b/kubernetes/apps/home/frigate/app/config/config.yml
@@ -25,13 +25,13 @@ auth:
   enabled: False
 
 detectors:
-  # worker-03 (PCIe Coral) was removed as dead hardware 2026-07-06;
-  # switched to OpenVINO on the Intel iGPU (workers 00/01/02)
-  ov:
-    type: openvino
-    device: GPU
-    model:
-      path: /openvino-model/ssdlite_mobilenet_v2.xml
+  # 2026-08-15: OpenVINO-on-iGPU attempt abandoned (0.17.2 plugin bugs:
+  # no model_path default, stat(None) crash). Coral detector restored;
+  # frigate scaled to 0 until the PCIe Coral is re-homed from dead
+  # worker-03 onto a live worker. Scale replicas back up on recovery.
+  coral:
+    type: edgetpu
+    device: pci
 
 ffmpeg:
   global_args: ["-hide_banner", "-loglevel", "warning"]

--- a/kubernetes/apps/home/frigate/app/helm-release.yaml
+++ b/kubernetes/apps/home/frigate/app/helm-release.yaml
@@ -34,6 +34,7 @@ spec:
   values:
     defaultPodOptions:
       nodeSelector:
+        google.feature.node.kubernetes.io/coral: 'true'
         intel.feature.node.kubernetes.io/gpu: 'true'
       affinity:
         podAntiAffinity:
@@ -47,6 +48,9 @@ spec:
     controllers:
       main:
         type: statefulset
+        # Scaled to 0 pending Coral recovery (worker-03 dead, OpenVINO
+        # fallback abandoned). Restore replicas on Coral re-home.
+        replicas: 0
         annotations:
           reloader.stakater.com/auto: 'true'
         containers:
@@ -159,3 +163,9 @@ spec:
         sizeLimit: 4Gi
         globalMounts:
           - path: /dev/shm
+      coral:
+        type: hostPath
+        hostPath: /dev/apex_0
+        hostPathType: CharDevice
+        globalMounts:
+          - path: /dev/apex_0


### PR DESCRIPTION
## Summary

Owner decision: kill the OpenVINO work and recover the Coral instead.

The OpenVINO fallback hit a wall of 0.17.2 bugs (per-detector `model:` blocks are nulled by the config validator — `frigate/config/config.py:477 'users should not set model themselves'`; openvino has no `model_path` default unlike cpu/edgetpu; `stat(None)` crash). Rather than fight it, frigate goes dormant until the PCIe Coral from dead worker-03 is re-homed.

## Changes

- **config.yml**: restore `coral: edgetpu/pci` detector, drop `ov:` block
- **helm-release**: restore coral+igpu nodeSelector and `/dev/apex_0` hostPath; set `controllers.main.replicas: 0`

Recovery procedure when Coral lands in a live worker: Talos passthrough config for `/dev/apex_0`, flip `replicas` back (one-line revert of this PR's replicas change).

## Kept (detector-independent, still correct at recovery)

- #2266/#2267 — 0.17.2 record retention schema (config validates regardless of detector)
- #2268 — hung reolink_e1_pro disabled (ICMP-only camera would trip the asyncio crash-loop with any detector)
- #2270 — startup probe (boot budget; harmless and needed with full config)

## Live state

STS already emergency-scaled to 0 via kubectl — crash-loop stopped, this PR makes it the declared state.