### PR TITLE
fix(ci): serialize brew downloads to stop .incomplete file race

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,6 +11,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
+# Serial bottle downloads: parallel fetches race on the *.incomplete
+# cache files (observed: "No such file or directory @ dir_s_rmdir" on
+# talosctl while cloudflared failed in the same brew bundle run).
+# HOMEBREW_DOWNLOAD_CONCURRENCY=1 trades a few seconds of install time
+# for deterministic brew runs. Applies to every brew invocation below.
+env:
+  HOMEBREW_DOWNLOAD_CONCURRENCY: "1"
+
 jobs:
   archlinux:
     name: workstation (archlinux)


### PR DESCRIPTION
## Summary

Fixes the flaky `configure (talos)` job: `brew bundle`'s parallel bottle downloads race on the download cache's `*.incomplete` marker files.

**Observed** (run 31871445979, and other sporadic failures): 
```
No such file or directory @ dir_s_rmdir - /home/runner/.cache/Homebrew/downloads/…--talosctl-linux-amd64.incomplete
Installing cloudflared has failed!
```
The rmdir names talosctl while cloudflared is reported failed — two parallel download threads stomping each other's partial-download bookkeeping. `HOMEBREW_DOWNLOAD_CONCURRENCY` defaults to `auto` (2× cores = 8 parallel on standard runners).

## Fix

`HOMEBREW_DOWNLOAD_CONCURRENCY: "1"` at workflow level in `e2e.yaml` — covers every brew invocation in all three jobs. Serial downloads cost a few seconds per run; the Brewfile is ~15 packages, negligible.

Not a cache-restoration issue: our cache path is `/home/linuxbrew/.linuxbrew` (prefix), not `~/.cache/Homebrew` (downloads) — the race is purely intra-run, so serializing eliminates it entirely.

Documented knob: brew manpage, ENVIRONMENT section (`If set to 1, Homebrew will download in serial`).