### PR TITLE
fix(ci): skip llm-provider[bot] PRs in AI review

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -5,7 +5,7 @@
 # per-PR concurrency group.
 #
 # The `uses:` ref MUST be a hardcoded tag (no vars context — see ai-workflows
-# README Lessons Learned #1). The renovate[bot] skip must stay in the caller (#4).
+# README Lessons Learned #1). The automation-bot skip must stay in the caller (#4).
 name: PR Review
 
 on:
@@ -20,8 +20,14 @@ permissions:
 
 jobs:
   review:
-    # Skip renovate[bot] PRs — handled by renovate-analysis.yml
-    if: github.event.pull_request.user.login != 'renovate[bot]'
+    # Skip automation-bot PRs. renovate[bot] PRs are analyzed by
+    # renovate-analysis.yml. llm-provider[bot] PRs (AI-generated fixes, e.g.
+    # mechanic remediation) can't be processed by the opencode action: its
+    # assertPermissions() requires the PR author to be a repo collaborator
+    # with write — app bot accounts are never collaborators, so the run fails
+    # before the AI reviews. The ai-workflows reusable workflow skips its own
+    # shared bot list; add org-specific bots here.
+    if: ${{ !contains(fromJson('["renovate[bot]","llm-provider[bot]"]'), github.event.pull_request.user.login) }}
     uses: lenaxia/ai-workflows/.github/workflows/pr-review.yml@v0.2.9
     secrets: inherit
     with:


### PR DESCRIPTION
## Why

The `Run OpenCode` step of the AI PR review fails for PRs authored by `llm-provider[bot]` (e.g. #2276):

```
Asserting permissions for user llm-provider[bot]...
  permission: none
User llm-provider[bot] does not have write permissions
```

The opencode action asserts the PR author is a repo collaborator with write permission for pull_request events. App bot accounts can never be collaborators, so the job fails before the AI reviews — this is unrelated to the 'Allow GitHub Actions to create and approve pull requests' setting (that only governs the formal `gh pr review --approve` step).

## What

Extend the caller-level skip (already used for renovate[bot]) to also skip `llm-provider[bot]` PRs, matching the bot-skip policy of the reusable ai-workflows pr-review.yml. Such PRs can be reviewed manually or via workflow_dispatch.