### PR TITLE
ci(renovate): realign stranded version: inputs to v0.2.10, exclude ai-workflows pins from Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,6 +57,18 @@
   packageRules: [
     {
       description: [
+        'ai-workflows pins are bumped by propagate.yml syncs only',
+      ],
+      matchManagers: [
+        'github-actions',
+      ],
+      matchPackageNames: [
+        'lenaxia/ai-workflows',
+      ],
+      enabled: false,
+    },
+    {
+      description: [
         'Auto merge Github Actions',
       ],
       matchManagers: [

--- a/.github/workflows/ai-comment.yml
+++ b/.github/workflows/ai-comment.yml
@@ -54,5 +54,5 @@ jobs:
     uses: lenaxia/ai-workflows/.github/workflows/ai-comment.yml@v0.2.10
     secrets: inherit
     with:
-      version: v0.2.9
+      version: v0.2.10
       project_name: talos-ops-prod

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -26,5 +26,5 @@ jobs:
     uses: lenaxia/ai-workflows/.github/workflows/issue-opened.yml@v0.2.10
     secrets: inherit
     with:
-      version: v0.2.9
+      version: v0.2.10
       project_name: talos-ops-prod

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -31,5 +31,5 @@ jobs:
     uses: lenaxia/ai-workflows/.github/workflows/pr-review.yml@v0.2.10
     secrets: inherit
     with:
-      version: v0.2.9
+      version: v0.2.10
       project_name: talos-ops-prod


### PR DESCRIPTION
## What

Fixes a **live pin strand on main** and prevents recurrence.

## Background — how main got stranded

Renovate's `Auto merge Github Actions` rule (`automergeType: 'branch'`, minor/patch) landed `22e5abac fix(github-action): update lenaxia/ai-workflows action to v0.2.10` directly on main (2026-08-15 18:26) — bumping only the `uses:` refs. Renovate's github-actions manager never updates `with:` inputs (only its built-in community `uses-with` table gets that), so the sibling callers' `version:` inputs stayed at **v0.2.9** while `uses:` moved to **v0.2.10**:

```
uses: lenaxia/ai-workflows/.github/workflows/pr-review.yml@v0.2.10
version: v0.2.9   ← stranded; it is the checkout ref for scripts/prompts
```

The workflow logic runs at v0.2.10 while scripts/prompts are checked out at v0.2.9. Worse, propagate.yml's repair path is now dead: its `s|version: OLD_TAG|version: NEW_TAG|g` sed derives `OLD_TAG` from the `uses:` line (already v0.2.10), so `version: v0.2.9` can never match again — on any future release.

## Changes

1. **`.github/workflows/{pr-review,ai-comment,issue-opened}.yml`** — `version: v0.2.9 → v0.2.10`, restoring the lockstep invariant (`uses:` was already v0.2.10).
2. **`.github/renovate.json5`** — new first packageRule disabling Renovate entirely for `lenaxia/ai-workflows` (`enabled: false`, exact `matchPackageNames` — a `owner/repo/**` glob would NOT match because depName is the bare `owner/repo`):
   ```json5
   {
     description: ['ai-workflows pins are bumped by propagate.yml syncs only'],
     matchManagers: ['github-actions'],
     matchPackageNames: ['lenaxia/ai-workflows'],
     enabled: false,
   }
   ```
   `enabled: false` (not just `automerge: false`): even a human-merged Renovate PR would bump `uses:` without `version:` and re-strand the pins. Pins move via propagate.yml lockstep syncs only.

## Verification

- `renovate.json5` parses (JSON5 validator), 26 packageRules.
- Sibling caller diffs are exactly `version: v0.2.9 → v0.2.10` (3 files, 1 line each).
- Org-wide tracking: lenaxia/ai-workflows#39 (same hazard exists in the onboarding template, k8s-mechanic, and the other onboarded consumers).