### PR TITLE
feat(llmsafespaces): bump to v0.15.12

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.15.11"
+        tag: "0.15.12"
       config:
         security:
           allowedOrigins:
@@ -113,22 +113,22 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.15.11"
+        tag: "0.15.12"
       # ── Agentd overlay delivery (LLMSafeSpaces #863) ───────────────────────
       # Deliver workspace-agentd to workspace pods via a digest-pinned
       # read-only image volume instead of the binary baked into
       # runtimes/base. The per-arch binary sha256s resolve at controller
       # startup from the image index annotations (stamped by CI's
       # merge-agentd job) — do NOT set binarySHA256*.
-      # Digest source: CI run 32069764691 (main @ 94dd9acd, 2026-08-17),
-      # "Merge Agentd Manifest" → "Print Helm values block" step. Index
-      # annotations verified present:
-      #   dev.llmsafespaces/agentd.sha256-amd64=d6827fd01344…e0716
-      #   dev.llmsafespaces/agentd.sha256-arm64=3732fcf1d3a5…44296
+      # Digest source: release v0.15.12 (Release workflow run 32266668142),
+      # "Merge Agentd Manifest" job → ghcr index annotations. Verified
+      # present on ghcr.io/lenaxia/llmsafespaces/agentd:0.15.12:
+      #   dev.llmsafespaces/agentd.sha256-amd64=78ea081d7190…82cc9
+      #   dev.llmsafespaces/agentd.sha256-arm64=f60451837c72…b7f3a
       # Rollback = delete this block (controller returns to legacy
       # baked-in mode); existing pods are unaffected (immutable specs).
       agentdDelivery:
-        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:35a1a5bb85a5f4f6a8491f89307e02ce00112165fd5d5d6beb6002b803986ce1
+        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:3d36506d6ba5a1be3218fbd06dd8b6a76b5f81496acfc4dd7712ae910ce4cbfc
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -147,7 +147,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.15.11"
+            tag: "0.15.12"
       freeModelsRefresher:
         enabled: false
 
@@ -218,7 +218,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.15.11"
+        tag: "0.15.12"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -237,7 +237,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.15.11"
+          tag: "0.15.12"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.15.11
+    tag: v0.15.12
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
Upgrades LLMSafeSpaces from v0.15.11 to v0.15.12 (released: https://github.com/lenaxia/LLMSafeSpaces/releases/tag/v0.15.12).

## What's in v0.15.12 (highlights for this cluster)

- **Dev preview now works** (#946/#948): the `devPreview.*` instance settings were unreachable on every stock deployment — no admin-UI switch, kill-switch hard-disabled at boot. This is the fix this workspace session root-caused; after rollout, the admin settings page gains a **Dev Preview** section, and dev preview is effectively ON by default for workspaces with the CRD toggle (kill via `devPreview.enabled=false` + API restart — live-kill-switch follow-up tracked in #946).
- **lib/pq dropped** (#945, GO-2026-6166..6173 — no fixed upstream release).
- **Relay `/provider` hang fixed** (#927/#911) — relevant to this cluster: the router renders with `inferenceRelay.enabled`.
- **agentd overlay live-validation fixes** (#926) — relevant to the `agentdDelivery` overlay pin below.
- **image-factory**: 409 name collisions, one-call default move, migration 000025 (single default) — the chart pre-upgrade migrate job applies it automatically.
- Epic 65 wire seam (usage/metering), image-factory base-update pill + refresh, G7 stress harness.

## Changes

- GitRepository ref `v0.15.11` → `v0.15.12` (atomic with the image pins per the file's own upgrade note)
- Five `image.tag` overrides → `0.15.12` (api, controller, relay-router, frontend, runtimeEnvironments.base)
- `agentdDelivery.image` digest → `sha256:3d36506d…ce4cbfc` (index annotations verified on ghcr: amd64 `78ea081d…82cc9`, arm64 `f6045183…b7f3a`; source: release run 32266668142)

## Rollout notes

- Migration 000025 runs via the chart's pre-upgrade job. Rollback = revert this PR (`.down.sql` mirrored in-chart).
- Post-rollout verification: admin settings page shows the Dev Preview section; workspace dev-preview URLs should serve through the tunnel.