### PR TITLE
docs: P0-4 runbook — disable CF body rewriters on the llmsafespaces zone

### DIFF
--- a/docs/cloudflare-body-rewriters-off-p0-4.md
+++ b/docs/cloudflare-body-rewriters-off-p0-4.md
@@ -1,0 +1,105 @@
+# P0-4 Runbook: Disable Cloudflare Body Rewriters on the LLMSafeSpaces Zone
+
+**Date:** 2026-08-19
+**Epic:** llmsafespaces epic-66 (dev preview) —
+`design/stories/epic-66-workspace-dev-preview/redesign-2026-08-19/` (llmsafespaces repo)
+**Why now:** P0-1 (edge `no-store`) and P0-2 (WS forwarding) are merged on
+llmsafespaces main. **P0-4 must land before Phase 2 (CSP relaxation)** —
+the sequencing constraint THREAT-MODEL T8: today the strict CSP
+accidentally blocks Cloudflare-injected scripts; once it relaxes, any
+still-active body rewriter's output would execute on preview origins.
+
+## Evidence (field-verified 2026-08-19)
+
+Responses from `api.safespaces.dev` (the zone fronting the workspace
+dev-preview tunnel) arrive with an injected script tag that the origin
+never sent:
+
+```html
+<script type="module" src="https://static.cloudflareinsights.com/beacon.min.js/v4513..." ...>
+```
+
+This is Cloudflare's automatic RUM beacon (Browser Insights / Web Analytics
+automatic instrumentation). Consequences through the dev-preview path:
+
+1. **Previews are not byte-accurate** — the developer sees bytes their
+   dev server never emitted.
+2. **Under the planned relaxed CSP, the injected script would execute**
+   on preview origins (T8 hazard).
+3. It proves an intermediary mutates HTML bodies — the same class of
+   actor that caused the original stale-cache debugging saga.
+
+## Scope of change (zone: safespaces.dev)
+
+Zone-level settings, **off for the whole zone**. There is no per-hostname
+exception for these features; if RUM is wanted elsewhere, use the manual
+Web Analytics snippet on chosen pages instead of automatic injection.
+
+| Feature | Dashboard path (names current as of 2026-08; CF reorganizes often) | API (zone_settings) |
+|---|---|---|
+| Web Analytics automatic beacon | Analytics & Logs → Web Analytics → automatic site ingestion / "inject the beacon" | discover via `GET zones/:id/zone_settings` (see below) |
+| Rocket Loader | Speed → Optimization → Content Optimization → Rocket Loader | `rocket_loader` = `off` |
+| Email Address Obfuscation | Scrape Shield → Email Address Obfuscation | `email_obfuscation` = `off` |
+| Auto Minify (JS/CSS/HTML) | Speed → Optimization | **removed by Cloudflare Aug 2024** — verify absent; no action if gone |
+
+**Honest note on the beacon toggle:** the RUM beacon's exact zone-settings
+key has moved across Cloudflare API revisions (Browser Insights →
+Web Analytics automatic instrumentation). Rather than hard-coding a
+possibly-stale key, discover it live:
+
+```bash
+CF_TOKEN=... ZONE_ID=...
+curl -s -H "Authorization: Bearer $CF_TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/zone_settings" \
+| python3 -c 'import json,sys; [print(s["id"], s["value"]) for s in json.load(sys.stdin)["result"] if s["id"] in ("rocket_loader","email_obfuscation","web_analytics","browser_insights","automatic_platform_optimization","minify")]'
+```
+
+Whatever key reports the beacon feature enabled — turn it off via
+`PATCH zones/:ID/zone_settings` with `{"items":[{"id":"<key>","value":"off"}]}`
+(value types vary; string toggles for the loader, "on"/"off").
+
+Requires a token with **Zone → Zone Settings → Edit** on the zone.
+
+## Why zone-wide is acceptable
+
+- `api.safespaces.dev` is an API origin; RUM beacons on JSON endpoints are
+  useless anyway.
+- The frontend SPA (`app.safespaces.dev`, if separate) does not need
+  automatic RUM; the manual snippet gives the same data with origin control.
+- Byte-accuracy of the dev-preview path is a product feature (epic-66);
+  silent mutation defeats it.
+
+## Verification (definitive, toggle-independent)
+
+The acceptance test from `ACCEPTANCE.md` §2.A4 — byte identity through the
+tunnel vs. in-pod origin. Run from inside a workspace with a dev server on
+:5173 and dev preview enabled:
+
+```bash
+# inside the pod
+curl -s http://127.0.0.1:5173/stress.html -o /tmp/local.html
+# through the tunnel (browser session cookie)
+curl -s --compressed -H "Cookie: lsp_session=<VALUE>" \
+  "https://api.safespaces.dev/api/v1/workspaces/<WS>/dev-preview/5173/stress.html" \
+  -o /tmp/tunnel.html
+diff /tmp/local.html /tmp/tunnel.html && echo BYTE-IDENTICAL
+grep -c beacon.min.js /tmp/tunnel.html   # must be 0
+```
+
+**PASS:** `BYTE-IDENTICAL` and grep count 0. Headers may differ (the API
+edge legitimately adds headers); bodies must not.
+
+Also verify Rocket Loader / obfuscation did not leave rewrites on non-HTML
+(dev servers serve JS/CSS): fetch one JS asset both ways and diff.
+
+## Rollback
+
+Re-enable the zone settings; re-run verification. No cluster state is
+touched by this change.
+
+## Status tracking
+
+- [ ] Beacon (Web Analytics automatic) off — verified by grep=0
+- [ ] Rocket Loader off — verified (HTML diff still byte-identical)
+- [ ] Email obfuscation off — verified
+- [ ] A4 byte-identity PASS recorded in epic-66 redesign thread

--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.15.11"
+        tag: "0.15.12"
       config:
         security:
           allowedOrigins:
@@ -113,22 +113,22 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.15.11"
+        tag: "0.15.12"
       # ── Agentd overlay delivery (LLMSafeSpaces #863) ───────────────────────
       # Deliver workspace-agentd to workspace pods via a digest-pinned
       # read-only image volume instead of the binary baked into
       # runtimes/base. The per-arch binary sha256s resolve at controller
       # startup from the image index annotations (stamped by CI's
       # merge-agentd job) — do NOT set binarySHA256*.
-      # Digest source: CI run 32069764691 (main @ 94dd9acd, 2026-08-17),
-      # "Merge Agentd Manifest" → "Print Helm values block" step. Index
-      # annotations verified present:
-      #   dev.llmsafespaces/agentd.sha256-amd64=d6827fd01344…e0716
-      #   dev.llmsafespaces/agentd.sha256-arm64=3732fcf1d3a5…44296
+      # Digest source: release v0.15.12 (Release workflow run 32266668142),
+      # "Merge Agentd Manifest" job → ghcr index annotations. Verified
+      # present on ghcr.io/lenaxia/llmsafespaces/agentd:0.15.12:
+      #   dev.llmsafespaces/agentd.sha256-amd64=78ea081d7190…82cc9
+      #   dev.llmsafespaces/agentd.sha256-arm64=f60451837c72…b7f3a
       # Rollback = delete this block (controller returns to legacy
       # baked-in mode); existing pods are unaffected (immutable specs).
       agentdDelivery:
-        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:35a1a5bb85a5f4f6a8491f89307e02ce00112165fd5d5d6beb6002b803986ce1
+        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:3d36506d6ba5a1be3218fbd06dd8b6a76b5f81496acfc4dd7712ae910ce4cbfc
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -147,7 +147,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.15.11"
+            tag: "0.15.12"
       freeModelsRefresher:
         enabled: false
 
@@ -218,7 +218,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.15.11"
+        tag: "0.15.12"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -237,7 +237,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.15.11"
+          tag: "0.15.12"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.15.11
+    tag: v0.15.12
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
Companion to llmsafespaces epic-66 redesign (Phase 0, item P0-4). P0-1 (edge no-store) and P0-2 (WS forwarding) are already merged upstream; **this is the remaining ops action, and it must precede Phase 2 (CSP relaxation) — THREAT-MODEL T8**: Cloudflare was observed (2026-08-19) injecting its RUM beacon into `api.safespaces.dev` HTML. Today the strict CSP blocks it by accident; after relaxation it would execute on preview origins.

The runbook covers: evidence, zone-wide toggles (beacon / Rocket Loader / email obfuscation), an API discovery command (the beacon's zone-settings key has moved across CF revisions — discover live instead of hard-coding), byte-identity verification that's independent of which toggle it was, and rollback.

No cluster state changes — zone settings only.