### PR TITLE
feat(llmsafespaces): bump to v0.16.0

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.15.12"
+        tag: "0.16.0"
       config:
         security:
           allowedOrigins:
@@ -113,22 +113,23 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.15.12"
+        tag: "0.16.0"
       # ── Agentd overlay delivery (LLMSafeSpaces #863) ───────────────────────
       # Deliver workspace-agentd to workspace pods via a digest-pinned
       # read-only image volume instead of the binary baked into
       # runtimes/base. The per-arch binary sha256s resolve at controller
       # startup from the image index annotations (stamped by CI's
       # merge-agentd job) — do NOT set binarySHA256*.
-      # Digest source: release v0.15.12 (Release workflow run 32266668142),
-      # "Merge Agentd Manifest" job → ghcr index annotations. Verified
-      # present on ghcr.io/lenaxia/llmsafespaces/agentd:0.15.12:
-      #   dev.llmsafespaces/agentd.sha256-amd64=78ea081d7190…82cc9
-      #   dev.llmsafespaces/agentd.sha256-arm64=f60451837c72…b7f3a
+      # Digest source: release v0.16.0 (Release workflow run 32326981354),
+      # ghcr index annotations, fetched anonymously from the registry and
+      # verified present on ghcr.io/lenaxia/llmsafespaces/agentd:0.16.0:
+      #   dev.llmsafespaces/agentd.sha256-amd64=f37608e646c4…c290
+      #   dev.llmsafespaces/agentd.sha256-arm64=f131c032a20f…eefc
+      #   dev.llmsafespaces/version=0.16.0
       # Rollback = delete this block (controller returns to legacy
       # baked-in mode); existing pods are unaffected (immutable specs).
       agentdDelivery:
-        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:3d36506d6ba5a1be3218fbd06dd8b6a76b5f81496acfc4dd7712ae910ce4cbfc
+        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:741004351dba1f70747d1c001692e56cf0f37a952ae65d002945b0e2a0f886b8
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -147,7 +148,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.15.12"
+            tag: "0.16.0"
       freeModelsRefresher:
         enabled: false
 
@@ -218,7 +219,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.15.12"
+        tag: "0.16.0"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -237,7 +238,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.15.12"
+          tag: "0.16.0"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.15.12
+    tag: v0.16.0
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
Upstream release **v0.16.0** ([release run 32326981354](https://github.com/lenaxia/LLMSafeSpaces/actions/runs/32326981354), published 2026-08-20T03:35Z, 9 assets).

## What's in it (relevant to this deployment)

- **Dev preview fixes (epic-66 P0-1/P0-2)**: the API edge now forces `Cache-Control: no-store` on HTML (the stale-preview caching saga), and WebSocket upgrades traverse the tunnel end-to-end — **HMR restored**, the epic's mandatory scope. Field-tested redesign docs: llmsafespaces `design/stories/epic-66-workspace-dev-preview/redesign-2026-08-19/`.
- **agentd fail-closed boot (#934)** + **distinct admin-mux token (#933)** — hardening.
- **D3 durable prompts (#943)** — Valkey outbox, accept-then-202.
- **Runtimes legacy-tree deletion (#959)** — no image impact (base only, as before).

## Changes

- `GitRepository` ref `v0.15.12` → `v0.16.0` (chart consumed from the tag)
- Five `image.tag` pins in lockstep (api, controller, frontend, relay-router, base RTE)
- agentd digest re-pinned: `sha256:74100435…886b8` — index annotations verified anonymously from ghcr (`amd64=f37608e6…c290`, `arm64=f131c032…eefc`, `version=0.16.0`)

## After merge

Flux reconciles (~30m interval, or force-sync). Then epic-66 Phase-0 live acceptance: A1 (no-store visible through the tunnel) + A2 (`ws-test.html` → PASS with `WS OPEN` in the workspace server log) — runbook in the llmsafespaces repo, `redesign-2026-08-19/ACCEPTANCE.md` §2.