### PR TITLE
feat(llmsafespaces): preview-origin ingress + wildcard cert (epic-66 P1-1b)

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/certificate-preview-origins.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/certificate-preview-origins.yaml
@@ -1,0 +1,18 @@
+---
+# Wildcard certificate for the grey-cloud *.safespaces.dev DNS record
+# (epic-66 preview origins): preview traffic bypasses Cloudflare, so
+# Traefik terminates TLS publicly. *.safespaces.dev covers every
+# <uuid>-preview.safespaces.dev host. DNS-01 via the existing
+# letsencrypt-production solver, which already handles this zone.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-safespaces-dev
+  namespace: llmsafespaces
+spec:
+  secretName: wildcard-safespaces-dev
+  dnsNames:
+    - "*.safespaces.dev"
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer

--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/ingress-preview-origins.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/ingress-preview-origins.yaml
@@ -1,0 +1,52 @@
+---
+# Epic 66 Phase 1 (llmsafespaces redesign-2026-08-19): per-workspace dev
+# preview origins. Routes <uuid>-preview.safespaces.dev to the API service,
+# which serves preview traffic through its dedicated pipeline (owner
+# bootstrap → one-time token → __Host-pv cookie) and NEVER serves /api/*.
+#
+# DNS: the zone already carries a grey-cloud (DNS-only) wildcard
+#   *.safespaces.dev → 76.135.100.247
+# so preview hostnames resolve directly to the cluster — traffic does NOT
+# traverse Cloudflare (byte-exact by construction; no CF cache/rewriters
+# in the path; direct WSS for HMR). TLS therefore terminates here and
+# needs a publicly-valid cert: certificate-preview-origins.yaml issues
+# *.safespaces.dev via the existing letsencrypt-production DNS-01 solver.
+#
+# Middleware choices (deliberate):
+#   - NO llmsafespaces-api-cors: that Allow-Origin policy is for the API
+#     origin; preview hosts must not receive it (T5 — the preview origin
+#     is a different trust domain).
+#   - NO chain-no-auth / secure-headers: the shared secure-headers sets
+#     accessControl* headers, which makes Traefik short-circuit OPTIONS
+#     preflights with no Allow-Origin (see middleware-cors.yaml header
+#     comment). Attaching it would break any cross-origin use of preview
+#     hosts (e.g. dashboard embedding later). The API's own security
+#     middleware sets the protective headers instead.
+#   - middlewares-rate-limit only: preview hosts are a public surface.
+#
+# The match is intentionally broad (any label before -preview): the API
+# validates the UUID shape and answers 421 for malformed hosts itself —
+# cluster edge and API agree on semantics.
+#
+# Inert until enabled: until the API's previewOrigin config ships and is
+# enabled (llmsafespaces ≥0.17.0 + secret), the API 404s preview-host
+# requests (no middleware registered). Fail-closed.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: llmsafespaces-preview-origins
+  namespace: llmsafespaces
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: HostRegexp(`^[a-z0-9-]+-preview\.safespaces\.dev$`)
+      kind: Rule
+      middlewares:
+        - name: middlewares-rate-limit
+          namespace: networking
+      services:
+        - name: llmsafespaces-api
+          port: 8080
+  tls:
+    secretName: wildcard-safespaces-dev

--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/kustomization.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/kustomization.yaml
@@ -9,5 +9,7 @@ resources:
   - helm-release.yaml
   - ingress-frontend.yaml
   - ingress-api.yaml
+  - ingress-preview-origins.yaml
+  - certificate-preview-origins.yaml
   - middleware-cors.yaml
   - secret.sops.yaml


### PR DESCRIPTION
Ops side of epic-66 Phase 1 (per-workspace preview origins), companion to llmsafespaces **#974** (merged) and **#976** (open).

## What

1. **Traefik IngressRoute** `<any>-preview.safespaces.dev` → `llmsafespaces-api:8080`. HostRegexp, deliberately broad — the API validates UUID shape and 421s malformed hosts itself; edge and API agree on semantics.
2. **cert-manager wildcard Certificate** `*.safespaces.dev` — DNS-01 via the existing `letsencrypt-production` Cloudflare solver (already configured for this zone).

## Why this shape

- **No DNS change needed**: the zone already carries a grey-cloud `*.safespaces.dev` A record → cluster IP. Preview traffic bypasses Cloudflare entirely — **byte-exact by construction** (no CF cache/rewriters in the path — P0-4's concern structurally gone for preview hosts), direct WSS for HMR. Grey DNS means TLS terminates at Traefik publicly → hence the wildcard cert.
- **Middleware minimalism (deliberate)**: rate-limit only. No `api-cors` (preview origins are a different trust domain — T5), no shared `secure-headers` (its accessControl\* headers make Traefik short-circuit OPTIONS preflights without Allow-Origin — the exact failure documented in middleware-cors.yaml; would break future cross-origin use of preview hosts).

## Inert until enabled (fail-closed)

Until llmsafespaces ≥0.17.0 (carrying #974/#976) deploys AND the operator adds the `preview-origin-token-secret` key to `llmsafespaces-credentials` + flips `previewOrigin.enabled`, the API 404s all preview-host requests. This PR can merge ahead of the release — it only adds routing for hostnames nothing serves yet.

## Verification after enablement

`curl -sI https://<uuid>-preview.safespaces.dev/5173/` → 401 (no credentials) with a valid cert chain; bootstrap flow per llmsafespaces #974's PR description.