### PR TITLE
feat(llmsafespaces): bump to v0.17.0 + enable per-workspace preview origins

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -102,7 +102,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.16.0"
+        tag: "0.17.0"
       config:
         security:
           allowedOrigins:
@@ -113,7 +113,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.16.0"
+        tag: "0.17.0"
       # ── Agentd overlay delivery (LLMSafeSpaces #863) ───────────────────────
       # Deliver workspace-agentd to workspace pods via a digest-pinned
       # read-only image volume instead of the binary baked into
@@ -129,7 +129,7 @@ spec:
       # Rollback = delete this block (controller returns to legacy
       # baked-in mode); existing pods are unaffected (immutable specs).
       agentdDelivery:
-        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:741004351dba1f70747d1c001692e56cf0f37a952ae65d002945b0e2a0f886b8
+        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:68b17987a11d9ae0d783e8504fe339682b55f62b000c9b05ffec98e47b3d3f21
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -148,7 +148,17 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.16.0"
+            tag: "0.17.0"
+      # ── Epic 66 Phase 1: per-workspace preview origins ──────────────────
+      # <uuid>-preview.safespaces.dev hosts served by the API's dedicated
+      # pipeline (owner bootstrap → one-time token → __Host-pv cookie).
+      # IngressRoute + wildcard cert landed in PR #2301. The token secret
+      # key preview-origin-token-secret MUST exist in llmsafespaces-
+      # credentials BEFORE Flux applies this — the API fail-closes at
+      # boot otherwise (see bump PR notes for the add command).
+      previewOrigin:
+        enabled: true
+        baseDomain: safespaces.dev
       freeModelsRefresher:
         enabled: false
 
@@ -219,7 +229,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.16.0"
+        tag: "0.17.0"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -238,7 +248,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.16.0"
+          tag: "0.17.0"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.16.0
+    tag: v0.17.0
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
Upstream **v0.17.0** ([release run 32343279412](https://github.com/lenaxia/LLMSafeSpaces/actions/runs/32343279412)) — the epic-66 Phase-1 release.

## What's in it
Per-workspace dev-preview origins: `<uuid>-preview.safespaces.dev` served by a dedicated API pipeline (owner bootstrap → one-time HMAC token → `__Host-pv` cookie). Platform session cookie never reaches preview hosts; preview hosts never serve `/api/*`; blocked/dead ports indistinguishable. `dev_preview_url` tool emits the bootstrap URL and refuses reserved ports pre-mint. Off-by-default upstream with a fail-closed boot guard; this PR is the enablement.

## Changes
- GitRepository ref `v0.16.0` → `v0.17.0`; five `image.tag` pins in lockstep
- agentd digest re-pinned: `sha256:68b17987…d3f21` (index annotations verified anonymously: amd64 `bd7cd2b0…`, arm64 `67812456…`, version 0.17.0)
- `previewOrigin: {enabled: true, baseDomain: safespaces.dev}` — activates the pipeline; ingress + wildcard cert already live from #2301 (cert verified serving `*.safespaces.dev` today)

## ⚠️ PREREQUISITE — do this BEFORE merging (fail-closed)

The API refuses to boot `previewOrigin.enabled=true` without the token secret. Add the key to the existing credentials Secret:

```bash
kubectl -n llmsafespaces patch secret llmsafespaces-credentials \
  --type merge -p \
  '{"stringData":{"preview-origin-token-secret":"PASTE_VALUE_FROM_AGENT"}}'
```

The value (64-char random, generated fresh — ask the agent for it, or generate your own: `openssl rand -base64 48 | tr -d '\n'`). It is the HMAC key for bootstrap tokens + `__Host-pv` cookies; rotating it later invalidates outstanding preview sessions (by design).

## After merge
Flux reconciles → API boots with preview origins → `https://<uuid>-preview.safespaces.dev/5173/` answers **401** (no credentials) instead of 404. Then live acceptance per ACCEPTANCE.md §3 (B1–B4), and Phase-2 CSP relaxation is unblocked.