### PR TITLE
fix(llmsafespaces): preview IngressRoute never matched — cross-ns middleware + v3 regex under v2 syntax

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/ingress-preview-origins.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/ingress-preview-origins.yaml
@@ -22,7 +22,12 @@
 #     comment). Attaching it would break any cross-origin use of preview
 #     hosts (e.g. dashboard embedding later). The API's own security
 #     middleware sets the protective headers instead.
-#   - middlewares-rate-limit only: preview hosts are a public surface.
+#   - llmsafespaces-preview-rate-limit (LOCAL middleware, defined in
+#     middleware-preview-ratelimit.yaml): preview hosts are a public
+#     surface, but Traefik runs WITHOUT allowCrossNamespace — referencing
+#     networking/middlewares-rate-limit from this namespace made the
+#     router error out and not match at all (root cause of the post-#2301
+#     404s). Local copy instead.
 #
 # The match is intentionally broad (any label before -preview): the API
 # validates the UUID shape and answers 421 for malformed hosts itself —
@@ -40,11 +45,10 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: HostRegexp(`^[a-z0-9-]+-preview\.safespaces\.dev$`)
+    - match: HostRegexp(`{host:[a-z0-9-]+-preview\.safespaces\.dev}`)
       kind: Rule
       middlewares:
-        - name: middlewares-rate-limit
-          namespace: networking
+        - name: llmsafespaces-preview-rate-limit
       services:
         - name: llmsafespaces-api
           port: 8080

--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/kustomization.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/kustomization.yaml
@@ -12,4 +12,5 @@ resources:
   - ingress-preview-origins.yaml
   - certificate-preview-origins.yaml
   - middleware-cors.yaml
+  - middleware-preview-ratelimit.yaml
   - secret.sops.yaml

--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/middleware-preview-ratelimit.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/middleware-preview-ratelimit.yaml
@@ -1,0 +1,17 @@
+---
+# Preview-origin rate limit (epic-66 Phase 1). LOCAL to this namespace
+# because Traefik runs without --providers.kubernetescrd.allowCrossNamespace
+# — a cross-namespace middleware reference makes the whole router error
+# out and not match (the bug that 404'd every preview host after #2301).
+# Mirrors networking/middlewares-rate-limit (avg 100 / burst 200).
+# Real per-workspace preview budgeting is the redesign's P1-5 (instrument
+# first); this is the interim edge guard at the cluster-standard rate.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: llmsafespaces-preview-rate-limit
+  namespace: llmsafespaces
+spec:
+  rateLimit:
+    average: 100
+    burst: 200


### PR DESCRIPTION
## Root cause of the preview-host 404s — edge, not app

The 404 was **Traefik's**, not gin's — proven by headers (no `x-request-id`, content-length 19 vs gin's 18; Traefik's default 404 body is byte-similar to gin's, which masked this across two rollouts while we verified everything *behind* the router: env in pods ✓, Helm v355 ✓, secret ✓, code in image ✓).

My #2301 IngressRoute had two independent router-killing defects:

1. **Cross-namespace middleware ref**: referenced `networking/middlewares-rate-limit` from the `llmsafespaces` namespace, but Traefik runs without `--providers.kubernetescrd.allowCrossNamespace` (checked the traefik HelmRelease). An invalid middleware reference makes the whole router error out and match **nothing**.
2. **Rule syntax**: cluster sets `defaultRuleSyntax: v2`; my `HostRegexp(`^…`)` is v3-style. Rewritten to canonical v2 brace form: `HostRegexp(`{host:[a-z0-9-]+-preview\.safespaces\.dev}`)`.

## Fix

- Local `llmsafespaces-preview-rate-limit` middleware in this namespace (avg 100 / burst 200, mirroring the cluster standard; per-workspace budgeting remains redesign P1-5)
- v2-syntax regex; no cross-namespace references remain

## Verify after merge

`curl -sI https://<uuid>-preview.safespaces.dev/5173/` → **401** (the API's preview middleware demanding credentials) with `x-request-id` present — vs today's Traefik 404 without.