### PR TITLE
feat(llmsafespaces): bump to v0.18.0

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -113,7 +113,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.17.0"
+        tag: "0.18.0"
       config:
         security:
           allowedOrigins:
@@ -124,7 +124,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.17.0"
+        tag: "0.18.0"
       # ── Agentd overlay delivery (LLMSafeSpaces #863) ───────────────────────
       # Deliver workspace-agentd to workspace pods via a digest-pinned
       # read-only image volume instead of the binary baked into
@@ -140,7 +140,7 @@ spec:
       # Rollback = delete this block (controller returns to legacy
       # baked-in mode); existing pods are unaffected (immutable specs).
       agentdDelivery:
-        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:68b17987a11d9ae0d783e8504fe339682b55f62b000c9b05ffec98e47b3d3f21
+        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:ccc96a39b76360d8e2e223448bb556e2d6f984606e926d1aac4dfc5f0f81908f
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -159,7 +159,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.17.0"
+            tag: "0.18.0"
       freeModelsRefresher:
         enabled: false
 
@@ -230,7 +230,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.17.0"
+        tag: "0.18.0"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -249,7 +249,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.17.0"
+          tag: "0.18.0"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.17.0
+    tag: v0.18.0
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
Upstream **v0.18.0** ([release run 32394012353](https://github.com/lenaxia/LLMSafeSpaces/actions/runs/32394012353)).

## Contents
- **Dev-preview landing page** (epic-66 Phase-1 UX, llmsafespaces #983) — browser navigations to `<uuid>-preview.safespaces.dev` now get a human front door (one-click bootstrap on deep links, no-JS port form on the bare host root); fetch/XHR/curl keep clean 401s; **no credential surface added** (static HTML, no scripts, test-enforced no-password).
- agentd sidecar split (#980) — **pod shape change**; SDKs/OpenAPI contract (#975); test restoration (#982).

## Changes
GitRepository ref → v0.18.0, five image.tag pins, agentd digest → `sha256:ccc96a39…1908f` (annotations verified: amd64 `ac476edc…`, arm64 `e29e25df…`, version 0.18.0). No values changes; previewOrigin stays enabled from 0.17.0.

## After merge
Verify: `curl -sI https://<ws>-preview.safespaces.dev/5173/` still 401 (no regression); then in a browser with a cleared `__Host-pv` cookie, that same URL should show the new landing page with **Open preview →**.