### PR TITLE
feat(llmsafespaces): bump to v0.19.0 — epic-66 completion

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -113,7 +113,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.18.0"
+        tag: "0.19.0"
       config:
         security:
           allowedOrigins:
@@ -124,7 +124,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.18.0"
+        tag: "0.19.0"
       # ── Agentd overlay delivery (LLMSafeSpaces #863) ───────────────────────
       # Deliver workspace-agentd to workspace pods via a digest-pinned
       # read-only image volume instead of the binary baked into
@@ -140,7 +140,7 @@ spec:
       # Rollback = delete this block (controller returns to legacy
       # baked-in mode); existing pods are unaffected (immutable specs).
       agentdDelivery:
-        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:ccc96a39b76360d8e2e223448bb556e2d6f984606e926d1aac4dfc5f0f81908f
+        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:cdcd53934bbf2a1141c4df0bccc4601e022b18fe8422a567290f2abbaa169691
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -159,7 +159,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.18.0"
+            tag: "0.19.0"
       freeModelsRefresher:
         enabled: false
 
@@ -230,7 +230,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.18.0"
+        tag: "0.19.0"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -249,7 +249,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.18.0"
+          tag: "0.19.0"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.18.0
+    tag: v0.19.0
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
Upstream **v0.19.0** ([release run 32417512888](https://github.com/lenaxia/LLMSafeSpaces/actions/runs/32417512888) — rerun after the outbox race-flake).

## Contents
- **Epic-66 Phase 2** (llmsafespaces #992): relaxed CSP on `<uuid>-preview` origins — inline scripts/styles/eval allowed (Next.js, Vue full-build), `connect-src 'self'` strict, API origin untouched. `frameAncestors` now configurable (we leave it empty = no embedding for now).
- **UX round 2** (#986): in-chat **Open dev preview** button, editable landing port + explainer, X-Forwarded-Host/Proto to dev servers.
- outbox verifying state machine (#993), D3 retry/dedupe (#964).

## Changes
ref → v0.19.0, five image pins, agentd digest → `sha256:cdcd5393…9691` (annotations verified: amd64 `5fa5233f…`, arm64 `ef0a311c…`).

## After merge
**Epic-66 final acceptance** (30 seconds): open the tunnel dashboard on the preview origin — every CSP line (eval, inline script/style) should flip to **allowed**. The same page that started this epic with a frozen clock and dead HMR.