### PR TITLE
feat(llmsafespaces): bump to v0.19.2 — landing CSP fix + outbox test fix

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -113,7 +113,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.19.0"
+        tag: "0.19.2"
       config:
         security:
           allowedOrigins:
@@ -124,7 +124,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.19.0"
+        tag: "0.19.2"
       # ── Agentd overlay delivery (LLMSafeSpaces #863) ───────────────────────
       # Deliver workspace-agentd to workspace pods via a digest-pinned
       # read-only image volume instead of the binary baked into
@@ -140,7 +140,7 @@ spec:
       # Rollback = delete this block (controller returns to legacy
       # baked-in mode); existing pods are unaffected (immutable specs).
       agentdDelivery:
-        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:cdcd53934bbf2a1141c4df0bccc4601e022b18fe8422a567290f2abbaa169691
+        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:d097cdfcab2853cf4a8b8d0dfcc20ae9b3d0e49fc5804450ed7486cf0792fbf1
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -159,7 +159,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.19.0"
+            tag: "0.19.2"
       freeModelsRefresher:
         enabled: false
 
@@ -230,7 +230,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.19.0"
+        tag: "0.19.2"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -249,7 +249,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.19.0"
+          tag: "0.19.2"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.19.0
+    tag: v0.19.2
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
Upstream **v0.19.2** ([release run 32433028917](https://github.com/lenaxia/LLMSafeSpaces/actions/runs/32433028917), tag CI green, agentd published & verified).

Supersedes **v0.19.1** — that tag's CI failed deterministically on the outbox race-detector hang (agentd never published; we hit the ghcr 404 mid-bump). 0.19.2 carries:
- **Landing form-action CSP fix** (#1000): the preview landing page's port form was blocked by its own `form-action 'self'` (cross-origin submit to the bootstrap endpoint) — the CTA was dead on arrival in 0.19.0. Landing now allowlists the API origin; app responses keep strict form-action.
- **Outbox test teardown fix** (#1005): the release-pipeline killer — test now wakes via a test-owned channel (detached-ctx interaction) with a 5s watchdog.

Changes: ref → v0.19.2, five image pins, agentd digest → `sha256:d097cdfc…fbf1` (annotations verified). After deploy: the landing page's **Open preview** form works — that's the acceptance.