### PR TITLE
feat(llmsafespaces): bump to v0.20.1 — outbox worker-join fix

### DIFF
--- a/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
+++ b/kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
@@ -113,7 +113,7 @@ spec:
     api:
       replicaCount: 2
       image:
-        tag: "0.19.2"
+        tag: "0.20.1"
       config:
         security:
           allowedOrigins:
@@ -124,7 +124,7 @@ spec:
       replicaCount: 1
       # Same semver-tag policy as api.image.tag above.
       image:
-        tag: "0.19.2"
+        tag: "0.20.1"
       # ── Agentd overlay delivery (LLMSafeSpaces #863) ───────────────────────
       # Deliver workspace-agentd to workspace pods via a digest-pinned
       # read-only image volume instead of the binary baked into
@@ -140,7 +140,7 @@ spec:
       # Rollback = delete this block (controller returns to legacy
       # baked-in mode); existing pods are unaffected (immutable specs).
       agentdDelivery:
-        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:d097cdfcab2853cf4a8b8d0dfcc20ae9b3d0e49fc5804450ed7486cf0792fbf1
+        image: ghcr.io/lenaxia/llmsafespaces/agentd@sha256:768538d1148eb921954ab0d17751896b2cfde150c008ea53e4c26854663b545e
       # InferenceRelay router enabled; fleet (cloud VMs) is NOT provisioned.
       # The relay-router Deployment renders in this namespace and the
       # controller's InferenceRelay reconciler starts, but no InferenceRelay
@@ -159,7 +159,7 @@ spec:
         # on main and every release tag builds all five.)
         router:
           image:
-            tag: "0.19.2"
+            tag: "0.20.1"
       freeModelsRefresher:
         enabled: false
 
@@ -230,7 +230,7 @@ spec:
       # in lockstep. The upstream release-tag build produces `frontend:0.8.0`
       # alongside the other four images.
       image:
-        tag: "0.19.2"
+        tag: "0.20.1"
       apiBaseUrl: https://api.safespaces.dev/api/v1
       ingress:
         enabled: false
@@ -249,7 +249,7 @@ spec:
     runtimeEnvironments:
       base:
         image:
-          tag: "0.19.2"
+          tag: "0.20.1"
 
     # ── Workspace defaults ──────────────────────────────────────────────────
     # Pin workspace PVCs to the 2-replica Longhorn StorageClass. Chart

--- a/kubernetes/flux/repositories/git/llmsafespaces.yaml
+++ b/kubernetes/flux/repositories/git/llmsafespaces.yaml
@@ -16,7 +16,7 @@ spec:
   # kubernetes/apps/llmsafespaces/llmsafespaces/app/helm-release.yaml
   # together in one PR.
   ref:
-    tag: v0.19.2
+    tag: v0.20.1
   ignore: |
     # exclude everything
     /*


### PR DESCRIPTION
Upstream **v0.20.1** ([release run 32455789308](https://github.com/lenaxia/LLMSafeSpaces/actions/runs/32455789308)) — first release through the **completed agentd pipeline** (3 agentd jobs ran inside the release workflow, per llmsafespaces #1008).

## Contents
- **Outbox Run worker-join fix** (llmsafespaces #1016): the root cause of the 10-minute race-detector hangs that killed the v0.19.1 and v0.20.0 release runs. Cancellation-proof bookkeeping (detached, fixed 5s bound, minted post-delivery). Verified 25x -race, zero failures/races.
- Everything intended for 0.20.0: US-3 agentd credential split, release-pipeline integrity + repolint invariant, **dev-preview chat-button relative-link fix** (the button actually renders now), env-pinned agentd tests.

## Changes
ref → v0.20.1, five image pins, agentd digest → sha256:768538d1…545e (annotations verified: amd64 a0c95f06…, arm64 60873785…).

## After merge
Flux rolls it; then the final unverified UX surface — the in-chat **Open dev preview** button — goes live (agentd + frontend both carry the fix). Ask any workspace agent for a preview URL and the button should appear.